### PR TITLE
Fix tutorial layout logic

### DIFF
--- a/content/docs/tutorials/async/helloasync-cpp.md
+++ b/content/docs/tutorials/async/helloasync-cpp.md
@@ -2,7 +2,7 @@
 layout: tutorials
 title: Asynchronous Basics - C++
 short: Async - C++
-type: async
+group: async
 ---
 
 This tutorial shows you how to write a simple server and client in C++ using

--- a/content/docs/tutorials/auth/oauth2-objective-c.md
+++ b/content/docs/tutorials/auth/oauth2-objective-c.md
@@ -2,8 +2,9 @@
 layout: tutorials
 title: OAuth2 on gRPC - Objective-C
 short: Auth - Objective-C
-type: auth
+group: auth
 ---
+
 This example demonstrates how to use OAuth2 on gRPC to make
 authenticated API calls on behalf of a user.
 

--- a/content/docs/tutorials/basic/android.md
+++ b/content/docs/tutorials/basic/android.md
@@ -2,7 +2,7 @@
 layout: tutorials
 title: gRPC Basics - Android Java
 short: Android
-type: basic
+group: basic
 ---
 
 This tutorial provides a basic Android Java programmer's introduction to working with gRPC.

--- a/content/docs/tutorials/basic/c.md
+++ b/content/docs/tutorials/basic/c.md
@@ -1,9 +1,10 @@
 ---
 layout: tutorials
 title: gRPC Basics - C++
-type: basic
+group: basic
 short: C
 ---
+
 This tutorial provides a basic C++ programmer's introduction to working with gRPC.
 
 By walking through this example you'll learn how to:

--- a/content/docs/tutorials/basic/csharp.md
+++ b/content/docs/tutorials/basic/csharp.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - C#
-type: basic
+group: basic
 short: C#
 ---
 This tutorial provides a basic C# programmer's introduction to working with gRPC.

--- a/content/docs/tutorials/basic/dart.md
+++ b/content/docs/tutorials/basic/dart.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Dart
-type: basic
+group: basic
 short: Dart
 ---
 This tutorial provides a basic Dart programmer's introduction to

--- a/content/docs/tutorials/basic/go.md
+++ b/content/docs/tutorials/basic/go.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Go
-type: basic
+group: basic
 short: Go
 ---
 This tutorial provides a basic Go programmer's introduction to

--- a/content/docs/tutorials/basic/java.md
+++ b/content/docs/tutorials/basic/java.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Java
-type: basic
+group: basic
 short: Java
 ---
 This tutorial provides a basic Java programmer's introduction to

--- a/content/docs/tutorials/basic/node.md
+++ b/content/docs/tutorials/basic/node.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Node.js
-type: basic
+group: basic
 short: Node
 ---
 This tutorial provides a basic Node.js programmer's introduction

--- a/content/docs/tutorials/basic/objective-c.md
+++ b/content/docs/tutorials/basic/objective-c.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Objective-C
-type: basic
+group: basic
 ---
 This tutorial provides a basic Objective-C programmer's
 introduction to working with gRPC.

--- a/content/docs/tutorials/basic/php.md
+++ b/content/docs/tutorials/basic/php.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - PHP
-type: basic
+group: basic
 short: PHP
 ---
 This tutorial provides a basic PHP programmer's introduction to

--- a/content/docs/tutorials/basic/python.md
+++ b/content/docs/tutorials/basic/python.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Python
-type: basic
+group: basic
 short: Python
 ---
 This tutorial provides a basic Python programmer's introduction

--- a/content/docs/tutorials/basic/ruby.md
+++ b/content/docs/tutorials/basic/ruby.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Ruby
-type: basic
+group: basic
 short: Ruby
 ---
 This tutorial provides a basic Ruby programmer's introduction to working with gRPC.

--- a/content/docs/tutorials/basic/web.md
+++ b/content/docs/tutorials/basic/web.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorials
 title: gRPC Basics - Web
-type: basic
+group: basic
 short: Web
 ---
 

--- a/layouts/docs/tutorials.html
+++ b/layouts/docs/tutorials.html
@@ -5,9 +5,9 @@
 {{ define "main" }}
 {{ $currentUrl := .RelPermalink }}
 {{ $tutorials  := where site.Pages ".Layout" "tutorials" }}
-{{ $async      := where $tutorials ".Params.type" "eq" "async" }}
-{{ $auth       := where $tutorials ".Params.type" "eq" "auth" }}
-{{ $basic      := where $tutorials ".Params.type" "eq" "basic" }}
+{{ $async      := where $tutorials ".Params.group" "eq" "async" }}
+{{ $auth       := where $tutorials ".Params.group" "eq" "auth" }}
+{{ $basic      := where $tutorials ".Params.group" "eq" "basic" }}
 
             <div class="headertext">Documentation</div>
   </div>


### PR DESCRIPTION
Apparently `type` is a reserved term in Hugo that shouldn't be used in page metadata. Lesson learned!

Addresses issue #8.