### PR TITLE
Remove End of Text control characters from HTML

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -6,7 +6,7 @@
     <div class="section2">
 
         <a name="arrow"><h1>Why gRPC?</h1></a>
-        gRPC is a modern open source high performance RPC framework that can run in any environment. It can efficiently connect services in and across data centers with pluggable support for load balancing, tracing, health checking and authentication. It is also applicable in last mile of distributed computing to connect devices, mobile applications and browsers to backend services.
+        gRPC is a modern open source high performance RPC framework that can run in any environment. It can efficiently connect services in and across data centers with pluggable support for load balancing, tracing, health checking and authentication. It is also applicable in last mile of distributed computing to connect devices, mobile applications and browsers to backend services.
 
 
     </div>
@@ -81,7 +81,7 @@ Define your service using Protocol Buffers, a powerful binary serialization tool
 
 <div class="section4">
     <h1 style="color:white">Want to Learn More?</h1>
-Get started by learning concepts and doing our hello world quickstart in language of your choice. <br>
+Get started by learning concepts and doing our hello world quickstart in language of your choice. <br>
     <div class="button" style="margin-top:3%">
                 <a href="docs/guides/concepts/"><button>GET STARTED</button></a>
             </div>


### PR DESCRIPTION
They are showing up with the square replacement character for me. End of
Text is aka ^C.