### PR TITLE
Update release URL

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -3,3 +3,4 @@
 /grpc-{{ . }}/*     https://grpc.github.io/grpc-{{ . }}/:splat
 {{ end -}}
 /grpc/*     https://grpc.github.io/grpc/:splat
+/release     https://grpc.github.io/release     200


### PR DESCRIPTION
Addresses issue #19.

This now works as expected:

```bash
curl -L https://deploy-preview-20--grpc-io.netlify.com/release
```