### PR TITLE
Fix Ruby API documentation link

### DIFF
--- a/content/docs/_index.html
+++ b/content/docs/_index.html
@@ -56,7 +56,7 @@ draft: false
 
 <a href="/docs/quickstart/ruby/">Quick Start Guide</a><br>
 <a href="/docs/tutorials/basic/ruby/">gRPC Basics Tutorial</a><br>
-<a href="https://godoc.org/google.golang.org/grpc">API Reference</a>
+<a href="https://www.rubydoc.info/gems/grpc">API Reference</a>
 <br>
   <h3 style="margin-top:3%;">Android Java</h3>
 


### PR DESCRIPTION
Previously, the `API Reference` link in the Ruby section of the website was a link to the documentation for Go rather than the link to the Ruby documentation. This PR updates that link to correctly point to the Ruby documentation