### PR TITLE
Add link to go generated code page

### DIFF
--- a/content/docs/reference/_index.html
+++ b/content/docs/reference/_index.html
@@ -17,6 +17,7 @@ weight: 4
     <li><a target="_blank" href="/grpc/csharp/api/Grpc.Core.html">C# API ("gRPC C#" implementation)</a></li>
     <li><a target="_blank" href="/grpc/csharp-dotnet/api/Grpc.Core.html">C# API ("grpc-dotnet" implementation)</a></li>
     <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">Go API</a></li>
+    <li><a target="_blank" href="https://grpc.io/docs/reference/go/generated-code/">Go Generated Code</a></li>
     <li><a target="_blank" href="/grpc/php/namespace-Grpc.html">PHP API</a></li>
     <li><a target="_blank" href="http://cocoadocs.org/docsets/gRPC/">Objective-C API</a></li>
     <li><a target="_blank" href="/grpc/core/">gRPC Core Library (for wrapped languages)</a></ul></li>


### PR DESCRIPTION
### Issue: https://github.com/grpc/grpc.io/issues/53
Add link to Go Generated Code page from the reference page. 
As previously, it seems that there is no entrance to that page from reference page.

Now there are 2 Go links
 - Go API -> go to godoc page
 - Go Generated Code -> go to Go Generated Code Reference page

