### PR TITLE
Remove links to microbenchmark data

### DIFF
--- a/content/docs/guides/benchmarking.md
+++ b/content/docs/guides/benchmarking.md
@@ -22,14 +22,6 @@ visualization.
   * [Multi-language performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584)
   * [C++ detailed performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5685265389584384)
 
-Additional benchmarking provides fine grained insights into where
-CPU is spent.
-
-  * [C++ full-stack microbenchmarks](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5684961520648192)
-  * [C Core filter benchmarks](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5740240702537728)
-  * [C Core shared component benchmarks](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5641826627223552&container=789696829&widget=512792852)
-  * [C Core HTTP/2 microbenchmarks](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5732910535540736)
-
 ### Performance testing design
 
 Each language implements a performance testing worker that implements


### PR DESCRIPTION
None of the dashboards contains any data, we don't populate them anymore. Removing link to the broken dashboards.