### PR TITLE
Update objc documents

### DIFF
--- a/content/docs/quickstart/objective-c.md
+++ b/content/docs/quickstart/objective-c.md
@@ -200,25 +200,27 @@ class GreeterServiceImpl final : public Greeter::Service {
 
 #### Update the client
 
-Edit `examples/objective-c/helloworld/main.m` to call the new method like this:
+Edit the main function in `examples/objective-c/helloworld/main.m` to call the new method like this:
 
 ```c
 int main(int argc, char * argv[]) {
   @autoreleasepool {
-    [GRPCCall useInsecureConnectionsForHost:kHostAddress];
-    [GRPCCall setUserAgentPrefix:@"HelloWorld/1.0" forHost:kHostAddress];
-
     HLWGreeter *client = [[HLWGreeter alloc] initWithHost:kHostAddress];
 
     HLWHelloRequest *request = [HLWHelloRequest message];
     request.name = @"Objective-C";
 
-    [client sayHelloWithRequest:request handler:^(HLWHelloReply *response, NSError *error) {
-      NSLog(@"%@", response.message);
-    }];
-    [client sayHelloAgainWithRequest:request handler:^(HLWHelloReply *response, NSError *error) {
-      NSLog(@"%@", response.message);
-    }];
+    GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
+    // this example does not use TLS (secure channel); use insecure channel instead
+    options.transport = GRPCDefaultTransportImplList.core_insecure;
+    options.userAgentPrefix = @"HelloWorld/1.0";
+
+    [[client sayHelloWithMessage:request
+                 responseHandler:[[HLWResponseHandler alloc] init]
+                     callOptions:options] start];
+    [[client sayHelloAgainWithMessage:request
+                      responseHandler:[[HLWResponseHandler alloc] init]
+                          callOptions:options] start];
 
     return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
   }

--- a/content/docs/reference/_index.html
+++ b/content/docs/reference/_index.html
@@ -18,6 +18,6 @@ weight: 4
     <li><a target="_blank" href="/grpc/csharp-dotnet/api/Grpc.Core.html">C# API ("grpc-dotnet" implementation)</a></li>
     <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">Go API</a></li>
     <li><a target="_blank" href="/grpc/php/namespace-Grpc.html">PHP API</a></li>
-    <li><a target="_blank" href="http://cocoadocs.org/docsets/gRPC/">Objective-C API</a></li>
+    <li><a target="_blank" href="/grpc/objc/index.html">Objective-C API</a></li>
     <li><a target="_blank" href="/grpc/core/">gRPC Core Library (for wrapped languages)</a></ul></li>
   </ul>  


### PR DESCRIPTION
* Update some Objective-C documents with old API usages.
* Update Objective-C API reference to point to the [new API reference](https://github.com/grpc/grpc/pull/20961) to be added in grpc/gh-pages