### PR TITLE
Fix typo in Ruby auth example.

### DIFF
--- a/content/docs/guides/auth.md
+++ b/content/docs/guides/auth.md
@@ -245,7 +245,7 @@ stub = Helloworld::Greeter::Stub.new('localhost:50051', :this_channel_is_insecur
 ##### With server authentication SSL/TLS
 
 ```ruby
-creds = GRPC::Core::Credentials.new(load_certs)  # load_certs typically loads a CA roots file
+creds = GRPC::Core::ChannelCredentials.new(load_certs)  # load_certs typically loads a CA roots file
 stub = Helloworld::Greeter::Stub.new('myservice.example.com', creds)
 ```
 


### PR DESCRIPTION
The auth guide has a Ruby example that references a non-existent `GRPC::Core::Credentials` class.

The class to use instead is `GRPC::Core::ChannelCredentials` as defined here:
https://github.com/grpc/grpc/blob/bebd20b126303a1f5d6cbb31d0463460b59c5074/src/ruby/ext/grpc/rb_channel_credentials.c#L237