### PR TITLE
Update the supported C++ versions

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -123,7 +123,7 @@ Check out what people are saying below:
 </tr>
 
 <tr>
-<td>C/C++</td><td>Linux/Mac</td><td>GCC 4.8+ <br> Clang 3.3+</td>
+<td>C/C++</td><td>Linux/Mac</td><td>GCC 4.9+ <br> Clang 3.4+</td>
 </tr>
 
 <tr>
@@ -175,7 +175,7 @@ Check out what people are saying below:
 
 | Language | Platform | Compiler |
 | -------- | -------- | -------- |
-| C/C++ | Linux/Mac | GCC 4.8+ <br> Clang 3.3+ |
+| C/C++ | Linux/Mac | GCC 4.9+ <br> Clang 3.4+ |
 | C/C++ | Windows 7+ | Visual Studio 2015+ |
 | C# | Linux/Mac | .NET Core, Mono 4+ |
 | C# | Windows 7+ | .NET Core, .NET 4.5+ |


### PR DESCRIPTION
As gRPC Core starts to be integrated with Abseil, it has to bump the minimum versions of supported C++ compiler to be par with Abseil. (reference: [abseil's supported platforms](https://abseil.io/docs/cpp/platforms/platforms)) The reason why the version of clang is bumped to 3.4 although it's not required by abseil is because we have a plan to use partial C++14 in near future and 3.4 is the first version to support it.

Changes:
- GCC: 4.8 -> 4.9
- Clang: 3.3 -> 3.4
