### PR TITLE
Add get_grpcurl installer

### DIFF
--- a/static/get_grpcurl
+++ b/static/get_grpcurl
@@ -3,7 +3,7 @@
 set -e
 
 UNATTENDED="false"
-if [ "$#" = "1" -a "$1" = "-y" ]; then
+if [ "$#" = "1" ] && [ "$1" = "-y" ]; then
   UNATTENDED="true"
 elif [ "$#" -gt 1 ]; then
   echo "Usage: $0 [-y]" 1>&2
@@ -43,7 +43,8 @@ confirm () {
     return 0
   fi
   echo "$1"
-  read -p "[y/n]" -r RESPONSE </dev/tty
+  printf "[y/n]"
+  read -r RESPONSE </dev/tty
   printf "\n"
   case "$RESPONSE" in
     "yes" | "y" | "YES" | "Y" ) return 0;;
@@ -65,7 +66,7 @@ modify_config_file () {
   FILE="$1"
   BIN_DIR="$2"
   BACKUP="${FILE}.bak.$(date | sed 's/ /-/g')"
-  if ! stat ${FILE} 1>/dev/null 2>&1; then
+  if ! stat "${FILE}" 1>/dev/null 2>&1; then
     return 1
   fi
   cp "${FILE}" "${BACKUP}"

--- a/static/get_grpcurl
+++ b/static/get_grpcurl
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+set -e
+
+detect_os () {
+  RAW_OS=$(uname -s)
+  OS="linux"
+  case "$RAW_OS" in
+    "Linux") OS="linux";;
+    "Darwin") OS="osx";;
+    *) echo "Unrecognized operating system \"${RAW_OS}\"" 1>&2; exit 1;;
+  esac
+  echo "${OS}"
+}
+
+detect_architecture () {
+  RAW_ARCH=$(uname -m)
+  ARCH="x86_64"
+  case "$RAW_ARCH" in
+    "x86_64") ARCH="x86_64";;
+    "i386") ARCH="x86_32";;
+    *) echo "Unrecognized architecture \"${RAW_ARCH}\"" 1>&2; exit 1;;
+  esac
+  echo "${ARCH}"
+}
+
+detect_platform () {
+  OS=$(detect_os)
+  ARCH=$(detect_architecture)
+  echo "${OS}_${ARCH}"
+}
+
+confirm () {
+  echo "$1"
+  read -p "[y/n]" RESPONSE </dev/tty
+  printf "\n"
+  case "$RESPONSE" in
+    "yes" | "y" ) return 0;;
+    "no" | "n" ) echo "Aborting." 1>&2; exit 1;;
+    *) echo "Unrecognized response. Aborting." 1>&2; exit 1;;
+  esac
+}
+
+ensure_command () {
+  if which "$1" 1>/dev/null 2>&1; then
+    return 0
+  else
+    echo "$1 is not installed. Please install it to proceed." 1>&2
+    exit 1
+  fi
+}
+
+GITHUB_URL="https://github.com"
+GRPCURL_REPO="fullstorydev/grpcurl"
+
+PLATFORM=$(detect_platform)
+
+BIN_DIR="${HOME}/.grpcurl/bin"
+
+confirm "This script will perform a user install of grpcurl. Would you like to proceed?"
+
+ensure_command "curl"
+
+mkdir -p "${BIN_DIR}"
+
+curl -Ls "${GITHUB_URL}/${GRPCURL_REPO}/releases/latest" | \
+  grep "href=.*${PLATFORM}.tar.gz" | \
+  cut -d '"' -f 2 | \
+  echo "${GITHUB_URL}$(cat -)" | \
+  curl -sL $(cat -) --output - | \
+  tar -C "${BIN_DIR}" -xzf - grpcurl
+
+cp ${HOME}/.bashrc ${HOME}/.bashrc.bak.$(date | sed 's/ /-/g')
+printf "\n# Added by https://grpc.io/get_grpcurl\nexport PATH=\"\$PATH:${BIN_DIR}\"\n" >> ${HOME}/.bashrc
+
+echo "${BIN_DIR} has been added to your PATH. Please open a new shell or source "
+echo "your .bashrc to use grpcurl."

--- a/static/get_grpcurl
+++ b/static/get_grpcurl
@@ -2,6 +2,14 @@
 
 set -e
 
+UNATTENDED="false"
+if [ "$#" = "1" -a "$1" = "-y" ]; then
+  UNATTENDED="true"
+elif [ "$#" -gt 1 ]; then
+  echo "Usage: $0 [-y]" 1>&2
+  exit 1
+fi
+
 detect_os () {
   RAW_OS=$(uname -s)
   OS="linux"
@@ -31,6 +39,9 @@ detect_platform () {
 }
 
 confirm () {
+  if [ "$UNATTENDED" = "true" ]; then
+    return 0
+  fi
   echo "$1"
   read -p "[y/n]" -r RESPONSE </dev/tty
   printf "\n"
@@ -54,7 +65,7 @@ modify_config_file () {
   FILE="$1"
   BIN_DIR="$2"
   BACKUP="${FILE}.bak.$(date | sed 's/ /-/g')"
-  if ! stat ${FILE} &>/dev/null; then
+  if ! stat ${FILE} 1>/dev/null 2>&1; then
     return 1
   fi
   cp "${FILE}" "${BACKUP}"

--- a/static/get_grpcurl
+++ b/static/get_grpcurl
@@ -32,17 +32,17 @@ detect_platform () {
 
 confirm () {
   echo "$1"
-  read -p "[y/n]" RESPONSE </dev/tty
+  read -p "[y/n]" -r RESPONSE </dev/tty
   printf "\n"
   case "$RESPONSE" in
-    "yes" | "y" ) return 0;;
-    "no" | "n" ) echo "Aborting." 1>&2; exit 1;;
+    "yes" | "y" | "YES" | "Y" ) return 0;;
+    "no" | "n" | "NO" | "N" ) echo "Aborting." 1>&2; exit 1;;
     *) echo "Unrecognized response. Aborting." 1>&2; exit 1;;
   esac
 }
 
 ensure_command () {
-  if which "$1" 1>/dev/null 2>&1; then
+  if command -v "$1" 1>/dev/null 2>&1; then
     return 0
   else
     echo "$1 is not installed. Please install it to proceed." 1>&2
@@ -67,11 +67,11 @@ curl -Ls "${GITHUB_URL}/${GRPCURL_REPO}/releases/latest" | \
   grep "href=.*${PLATFORM}.tar.gz" | \
   cut -d '"' -f 2 | \
   echo "${GITHUB_URL}$(cat -)" | \
-  curl -sL $(cat -) --output - | \
+  curl -sL "$(cat -)" --output - | \
   tar -C "${BIN_DIR}" -xzf - grpcurl
 
-cp ${HOME}/.bashrc ${HOME}/.bashrc.bak.$(date | sed 's/ /-/g')
-printf "\n# Added by https://grpc.io/get_grpcurl\nexport PATH=\"\$PATH:${BIN_DIR}\"\n" >> ${HOME}/.bashrc
+cp "${HOME}/.bashrc" "${HOME}/.bashrc.bak.$(date | sed 's/ /-/g')"
+printf "\n# Added by https://grpc.io/get_grpcurl\nexport PATH=\"\$PATH:%s\"\n" "${BIN_DIR}" >> "${HOME}/.bashrc"
 
 echo "${BIN_DIR} has been added to your PATH. Please open a new shell or source "
 echo "your .bashrc to use grpcurl."

--- a/static/get_grpcurl
+++ b/static/get_grpcurl
@@ -8,7 +8,7 @@ detect_os () {
   case "$RAW_OS" in
     "Linux") OS="linux";;
     "Darwin") OS="osx";;
-    *) echo "Unrecognized operating system \"${RAW_OS}\"" 1>&2; exit 1;;
+    *) echo "Unsupported operating system \"${RAW_OS}\"" 1>&2; exit 1;;
   esac
   echo "${OS}"
 }
@@ -19,7 +19,7 @@ detect_architecture () {
   case "$RAW_ARCH" in
     "x86_64") ARCH="x86_64";;
     "i386") ARCH="x86_32";;
-    *) echo "Unrecognized architecture \"${RAW_ARCH}\"" 1>&2; exit 1;;
+    *) echo "Unsupported architecture \"${RAW_ARCH}\"" 1>&2; exit 1;;
   esac
   echo "${ARCH}"
 }
@@ -50,6 +50,27 @@ ensure_command () {
   fi
 }
 
+modify_config_file () {
+  FILE="$1"
+  BIN_DIR="$2"
+  BACKUP="${FILE}.bak.$(date | sed 's/ /-/g')"
+  if ! stat ${FILE} &>/dev/null; then
+    return 1
+  fi
+  cp "${FILE}" "${BACKUP}"
+  printf "\n# Added by https://grpc.io/get_grpcurl\nexport PATH=\"\$PATH:%s\"\n" "${BIN_DIR}" >> "${FILE}"
+}
+
+ensure_command "curl"
+ensure_command "cut"
+ensure_command "cp"
+ensure_command "date"
+ensure_command "grep"
+ensure_command "mkdir"
+ensure_command "sed"
+ensure_command "stat"
+ensure_command "uname"
+
 GITHUB_URL="https://github.com"
 GRPCURL_REPO="fullstorydev/grpcurl"
 
@@ -58,8 +79,6 @@ PLATFORM=$(detect_platform)
 BIN_DIR="${HOME}/.grpcurl/bin"
 
 confirm "This script will perform a user install of grpcurl. Would you like to proceed?"
-
-ensure_command "curl"
 
 mkdir -p "${BIN_DIR}"
 
@@ -70,8 +89,8 @@ curl -Ls "${GITHUB_URL}/${GRPCURL_REPO}/releases/latest" | \
   curl -sL "$(cat -)" --output - | \
   tar -C "${BIN_DIR}" -xzf - grpcurl
 
-cp "${HOME}/.bashrc" "${HOME}/.bashrc.bak.$(date | sed 's/ /-/g')"
-printf "\n# Added by https://grpc.io/get_grpcurl\nexport PATH=\"\$PATH:%s\"\n" "${BIN_DIR}" >> "${HOME}/.bashrc"
+modify_config_file "${HOME}/.bashrc" "${BIN_DIR}" || \
+modify_config_file "${HOME}/.bash_profile" "${BIN_DIR}" || \
+modify_config_file "${HOME}/.profile" "${BIN_DIR}"
 
-echo "${BIN_DIR} has been added to your PATH. Please open a new shell or source "
-echo "your .bashrc to use grpcurl."
+echo "${BIN_DIR} has been added to your PATH. Please open a new shell to use grpcurl."


### PR DESCRIPTION
This PR introduces an experimental one-line installer for `grpcurl`. It has been manually tested on Mac OS and several linux distros. For the moment, this is completely unsupported and undocumented.

The intent is to enable people to run `curl -s https://grpc.io/get_grpcurl | bash`. For obvious reasons, this script does not require root.

CC @lidizheng 