### PR TITLE
Fix heading formatting for basic Java server implementation

### DIFF
--- a/content/docs/tutorials/basic/java.md
+++ b/content/docs/tutorials/basic/java.md
@@ -214,7 +214,7 @@ private static class RouteGuideService extends RouteGuideGrpc.RouteGuideImplBase
 }
 ```
 
-#### Simple RPC 
+#### Simple RPC
 
 `RouteGuideService` implements all our service methods. Let's
 look at the simplest type first, `GetFeature`, which just gets a `Point` from
@@ -258,7 +258,7 @@ To return our response to the client and complete the call:
 3. We use the response observer's `onCompleted()` method to specify that we've
    finished dealing with the RPC.
 
-##### Server-side streaming RPC
+#### Server-side streaming RPC
 Next let's look at one of our streaming RPCs. `ListFeatures` is a server-side
 streaming RPC, so we need to send back multiple `Feature`s to our client.
 
@@ -299,7 +299,7 @@ the response observer using its `onNext()` method. Finally, as in our simple
 RPC, we use the response observer's `onCompleted()` method to tell gRPC that
 we've finished writing responses.
 
-##### Client-side streaming RPC
+#### Client-side streaming RPC
 Now let's look at something a little more complicated: the client-side streaming
 method `RecordRoute`, where we get a stream of `Point`s from the client and
 return a single `RouteSummary` with information about their trip.
@@ -359,7 +359,7 @@ which we:
   method's own response observer's `onNext()` with our `RouteSummary`, and then
   call its `onCompleted()` method to finish the call from the server side.
 
-##### Bidirectional streaming RPC
+#### Bidirectional streaming RPC
 
 Finally, let's look at our bidirectional streaming RPC `RouteChat()`.
 


### PR DESCRIPTION
The headings for the documentation [here](https://grpc.io/docs/tutorials/basic/java/) under the _Creating the server_ section doesn't seem consistent. Dropping the extra #.
