### PR TITLE
Android QS and Tutorial cleanup

### DIFF
--- a/content/docs/quickstart/android.md
+++ b/content/docs/quickstart/android.md
@@ -11,7 +11,7 @@ description: This guide gets you started with gRPC in Android Java with a simple
 
 #### Prerequisites
 
-*   `JDK`: version 7 or higher
+*   JDK: version 7 or higher
 *   Android SDK: API level 14 or higher
 *   An android device set up for [USB
     debugging](https://developer.android.com/studio/command-line/adb.html#Enabling)
@@ -30,32 +30,32 @@ clones the entire repository, but you just need the examples for this quickstart
 and other tutorials):
 
 ```sh
-$ # Clone the repository at the latest release to get the example code:
+# Clone the repository at the latest release to get the example code:
 $ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java
-$ # Navigate to the Java examples:
+# Navigate to the Java examples:
 $ cd grpc-java/examples
 ```
 
 ### Run a gRPC application
 
-1. Compile the server
+ 1. Compile the server
 
-   ```sh
-   $ ./gradlew installDist
-   ```
+    ```sh
+    $ ./gradlew installDist
+    ```
 
-2. Run the server
+ 2. Run the server
 
-   ```sh
-   $ ./build/install/examples/bin/hello-world-server
-   ```
+    ```sh
+    $ ./build/install/examples/bin/hello-world-server
+    ```
 
-3. In another terminal, compile and run the client
+ 3. In another terminal, compile and run the client
 
-   ```sh
-   $ cd android/helloworld
-   $ ../../gradlew installDebug
-   ```
+    ```sh
+    $ cd android/helloworld
+    $ ../../gradlew installDebug
+    ```
 
 Congratulations! You've just run a client-server application with gRPC.
 
@@ -70,7 +70,7 @@ server and the client "stub" have a `SayHello` RPC method that takes a
 server, and that this method is defined like this:
 
 
-```java
+```protobuf
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
@@ -91,7 +91,7 @@ Let's update this so that the `Greeter` service has two methods. Edit
 `src/main/proto/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
-```java
+```protobuf
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
@@ -151,24 +151,24 @@ method like this:
 
 Just like we did before, from the `examples` directory:
 
-1. Compile the server
+ 1. Compile the server
 
-   ```sh
-   $ ./gradlew installDist
-   ```
+    ```sh
+    $ ./gradlew installDist
+    ```
 
-2. Run the server
+ 2. Run the server
 
-   ```sh
-   $ ./build/install/examples/bin/hello-world-server
-   ```
+    ```sh
+    $ ./build/install/examples/bin/hello-world-server
+    ```
 
-3. In another terminal, compile and install the client to your device
+ 3. In another terminal, compile and install the client to your device
 
-   ```sh
-   $ cd android/helloworld
-   $ ../../gradlew installDebug
-   ```
+    ```sh
+    $ cd android/helloworld
+    $ ../../gradlew installDebug
+    ```
 
 #### Connecting to the Hello World server via USB
 
@@ -198,7 +198,7 @@ enter `10.0.2.2` and `50051` as the `Host` and `Port`.
 ### What's next
 
 - Read a full explanation of how gRPC works in [What is gRPC?](/docs/guides/)
-  and [gRPC Concepts](/docs/guides/concepts/)
-- Work through a more detailed tutorial in [gRPC Basics: Android Java](/docs/tutorials/basic/android/)
+  and [gRPC Concepts](/docs/guides/concepts/).
+- Work through a more detailed tutorial in [gRPC Basics: Android Java](/docs/tutorials/basic/android/).
 - Explore the gRPC Java core API in its [reference
-  documentation](/grpc-java/javadoc/)
+  documentation](/grpc-java/javadoc/).

--- a/content/docs/quickstart/java.md
+++ b/content/docs/quickstart/java.md
@@ -11,7 +11,7 @@ description: This guide gets you started with gRPC in Java with a simple working
 
 #### Prerequisites
 
-* `JDK`: version 7 or higher
+* JDK: version 7 or higher
 
 ### Download the example
 
@@ -193,8 +193,8 @@ Just like we did before, from the `examples` directory:
 ### What's next
 
 - Read a full explanation of how gRPC works in [What is gRPC?](/docs/guides/)
-  and [gRPC Concepts](/docs/guides/concepts/)
-- Work through a more detailed tutorial in [gRPC Basics: Java](/docs/tutorials/basic/java/)
+  and [gRPC Concepts](/docs/guides/concepts/).
+- Work through a more detailed tutorial in [gRPC Basics: Java](/docs/tutorials/basic/java/).
 - Explore the gRPC Java core API in its [reference
-  documentation](/grpc-java/javadoc/)
+  documentation](/grpc-java/javadoc/).
 

--- a/content/docs/tutorials/basic/android.md
+++ b/content/docs/tutorials/basic/android.md
@@ -26,7 +26,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 ### Example code and setup
 
-The example code for our tutorial is in [grpc-java's examples/android](https://github.com/grpc/grpc-java/tree/{{< param grpc_release_tag >}}/examples/android). To download the example, clone the `grpc-java` repository by running the following command:
+The example code for our tutorial is in [grpc-java's examples/android](https://github.com/grpc/grpc-java/tree/{{< param grpc_java_release_tag >}}/examples/android). To download the example, clone the `grpc-java` repository by running the following command:
 
 ```sh
 $ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java.git
@@ -38,12 +38,12 @@ Then change your current directory to `grpc-java/examples/android`:
 $ cd grpc-java/examples/android
 ```
 
-You also should have the relevant tools installed to generate the client interface code - if you don't already, follow the setup instructions in [the Java README](https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/README.md).
+You also should have the relevant tools installed to generate the client interface code - if you don't already, follow the setup instructions in [the Java README](https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/README.md).
 
 
 ### Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`routeguide/app/src/main/proto/route_guide.proto`](https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`routeguide/app/src/main/proto/route_guide.proto`](https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
 
 As we're generating Java code in this example, we've specified a `java_package` file option in our .proto:
 
@@ -120,8 +120,8 @@ both proto2 and proto3 syntax) in order to generate gRPC services.
 
 The build system for this example is also part of Java gRPC itself's build. You
 can refer to the <a
-href="https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/README.md">README</a> and
-<a href="https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/examples/android/routeguide/app/build.gradle#L26">build.gradle</a> for
+href="https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/README.md">README</a> and
+<a href="https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/build.gradle#L26">build.gradle</a> for
 how to generate code from your own .proto files.
 Note that for Android, we will use protobuf lite which is optimized for mobile usecase.
 
@@ -139,7 +139,7 @@ The following classes are generated from our service definition:
 
 ### Creating the client
 
-In this section, we'll look at creating a Java client for our `RouteGuide` service. You can see our complete example client code in [`routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java`](https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java).
+In this section, we'll look at creating a Java client for our `RouteGuide` service. You can see our complete example client code in [`routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java`](https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java).
 
 #### Creating a stub
 
@@ -340,5 +340,7 @@ As with our client-side streaming example, we both get and return a `StreamObser
 
 ### Try it out!
 
-Follow the instructions in the example directory [README](https://github.com/grpc/grpc-java/blob/{{< param grpc_release_tag >}}/examples/android/README.md) to build and run the client and server.
+Follow the instructions in the [example directory README][] to build and run the
+client and server.
 
+[example directory README]: https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/README.md


### PR DESCRIPTION
Contributes to #87 and #88 for Android.

Also switched to using `grpc_java_release_tag` rather than the general `grpc_release_tag` to generate URLs to repo files.