### PR TITLE
Add SEO metadata

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ unsafe = true
 style = "manni"
 
 [params]
+locale = "en_US"
 grpc_release_tag = "v1.27.2"
 grpc_release_tag_no_v = "1.27.2"
 grpc_java_release_tag = "v1.27.2"
@@ -27,6 +28,7 @@ gRPC is a modern open source high performance RPC framework that can run in any 
 twitter = "https://twitter.com/grpcio"
 gitter = "https://gitter.im/grpc/grpc"
 reddit = "https://www.reddit.com/r/grpc"
+twitter_handle = "grpcio"
 
 [[params.features]]
 title = "Simple service definition"

--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ gRPC is a modern open source high performance RPC framework that can run in any 
 twitter = "https://twitter.com/grpcio"
 gitter = "https://gitter.im/grpc/grpc"
 reddit = "https://www.reddit.com/r/grpc"
-twitter_handle = "grpcio"
+twitter_handle = "@grpcio"
 
 [[params.features]]
 title = "Simple service definition"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 {{ $currentUrl := .RelPermalink }}
 {{ $lang       := site.LanguageCode }}
 <!DOCTYPE html>
-<html lang="{{ $lang }}">
+<html lang="{{ $lang }}" prefix="og: http://ogp.me/ns#">
   <head>
     {{ partial "google-analytics.html" . }}
     {{ partial "meta.html" . }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,16 +1,14 @@
-{{ $url     := .Permalink }}
 {{ $title   := cond .IsHome site.Title .Title }}
 {{ $type    := cond .IsHome "website" "article" }}
 {{ $desc    := .Param "description" }}
-{{ $twitter := printf "@%s" site.Params.social.twitter_handle }}
+{{ $twitter := site.Params.social.twitter_handle }}
 {{ $img     := "img/logos/grpc-icon-color.png" | absURL }}
 {{ $imgAlt  := printf "%s color logo" site.Title }}
-{{ $locale  := site.Params.locale }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 {{ with .OutputFormats.Get "rss" -}}
-{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
 {{ end -}}
 
 {{/* Twitter Card metadata */}}
@@ -21,7 +19,7 @@
 <meta name="twitter:image:alt" content="{{ $imgAlt }}">
 
 {{/* OpenGraph metadata */}}
-<meta property="og:url" content="{{ $url }}">
+<meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:title" content="{{ $title }}">
 {{ with $desc }}
 <meta property="og:description" content="{{ $desc }}">
@@ -31,4 +29,4 @@
 <meta property="og:image" content="{{ $img }}">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:alt" content="{{ $imgAlt }}">
-<meta property="og:locale" content="{{ $locale }}">
+<meta property="og:locale" content="{{ site.Params.locale }}">

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,6 +1,34 @@
+{{ $url     := .Permalink }}
+{{ $title   := cond .IsHome site.Title .Title }}
+{{ $type    := cond .IsHome "website" "article" }}
+{{ $desc    := .Param "description" }}
+{{ $twitter := printf "@%s" site.Params.social.twitter_handle }}
+{{ $img     := "img/logos/grpc-icon-color.png" | absURL }}
+{{ $imgAlt  := printf "%s color logo" site.Title }}
+{{ $locale  := site.Params.locale }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 {{ with .OutputFormats.Get "rss" -}}
 {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{ end -}}
+
+{{/* Twitter Card metadata */}}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="{{ $twitter }}">
+<meta name="twitter:creator" content="{{ $twitter }}">
+<meta name="twitter:image" content="{{ $img }}">
+<meta name="twitter:image:alt" content="{{ $imgAlt }}">
+
+{{/* OpenGraph metadata */}}
+<meta property="og:url" content="{{ $url }}">
+<meta property="og:title" content="{{ $title }}">
+{{ with $desc }}
+<meta property="og:description" content="{{ $desc }}">
+{{ end }}
+<meta property="og:type" content="{{ $type }}">
+<meta property="og:site_name" content="{{ site.Title }}">
+<meta property="og:image" content="{{ $img }}">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:alt" content="{{ $imgAlt }}">
+<meta property="og:locale" content="{{ $locale }}">


### PR DESCRIPTION
This PR adds OpenGraph and Twitter Card metadata to each page's `head` block.