### PR TITLE
Update min Dart SDK to 2.2+

### DIFF
--- a/content/docs/quickstart/dart.md
+++ b/content/docs/quickstart/dart.md
@@ -7,13 +7,13 @@ description: This guide gets you started with gRPC in Dart with a simple working
 
 ### Prerequisites
 
-- Dart SDK version 2.0 or higher.
+- Dart SDK version 2.2 or higher.
 
 For installation instructions, see [Install Dart](https://dart.dev/install).
 
 {{< note >}}
 Dart gRPC supports the Flutter and Server platforms.
-{{< /note >}} 
+{{< /note >}}
 
 #### Protocol Buffers v3
 

--- a/content/faq.md
+++ b/content/faq.md
@@ -31,9 +31,7 @@ Google has been using a lot of the underlying technologies and concepts in gRPC 
 
 ### Which programming languages are supported?
 
-C++, Java (incl. support for Android), Objective-C (for iOS), Python, Ruby, Go, C#, Node.js are in GA and follow semantic versioning.
-
-Dart support is in beta.
+C++, Java (including support for Android), Objective-C (for iOS), Python, Ruby, Go, C#, Node.js are in GA and follow semantic versioning.
 
 ### How do I get started using gRPC?
 

--- a/data/platforms.yaml
+++ b/data/platforms.yaml
@@ -12,7 +12,7 @@
   compilers: [".NET Core", "NET 4.5+"]
 - language: "Dart"
   platforms: ["Windows", "Linux", "Mac"]
-  compilers: ["Dart 2.0+"]
+  compilers: ["Dart 2.2+"]
 - language: "Go"
   platforms: ["Windows", "Linux", "Mac"]
   compilers: ["Go 1.6+"]


### PR DESCRIPTION
Closes #133. Also removes statement that claimed that Dart `grpc` package was in beta.