### PR TITLE
Simplify syntax in example code

### DIFF
--- a/content/docs/guides/_index.md
+++ b/content/docs/guides/_index.md
@@ -65,7 +65,7 @@ protocol buffer messages:
 // The greeter service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/android.md
+++ b/content/docs/quickstart/android.md
@@ -71,7 +71,7 @@ server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -92,9 +92,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/cpp.md
+++ b/content/docs/quickstart/cpp.md
@@ -183,7 +183,7 @@ server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -204,9 +204,9 @@ same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/csharp.md
+++ b/content/docs/quickstart/csharp.md
@@ -93,7 +93,7 @@ server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -115,9 +115,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/dart.md
+++ b/content/docs/quickstart/dart.md
@@ -102,7 +102,7 @@ server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -123,9 +123,9 @@ same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/go.md
+++ b/content/docs/quickstart/go.md
@@ -100,7 +100,7 @@ is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -125,9 +125,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/java.md
+++ b/content/docs/quickstart/java.md
@@ -62,7 +62,7 @@ server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -83,9 +83,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/node.md
+++ b/content/docs/quickstart/node.md
@@ -58,7 +58,7 @@ method that takes a `HelloRequest` parameter from the client and returns a
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -80,9 +80,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/objective-c.md
+++ b/content/docs/quickstart/objective-c.md
@@ -129,7 +129,7 @@ RPC method that takes a `HelloRequest` parameter from the client and returns a
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -151,9 +151,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/php.md
+++ b/content/docs/quickstart/php.md
@@ -311,7 +311,7 @@ the server, and that this method is defined like this:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -333,9 +333,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/python.md
+++ b/content/docs/quickstart/python.md
@@ -115,7 +115,7 @@ method that takes a `HelloRequest` parameter from the client and returns a
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -137,9 +137,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/quickstart/ruby.md
+++ b/content/docs/quickstart/ruby.md
@@ -80,7 +80,7 @@ method that takes a `HelloRequest` parameter from the client and returns a
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.
@@ -102,9 +102,9 @@ method, with the same request and response types:
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
   // Sends another greeting
-  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/content/docs/tutorials/basic/android.md
+++ b/content/docs/tutorials/basic/android.md
@@ -67,7 +67,7 @@ Then we define `rpc` methods inside our service definition, specifying their req
 
   ```proto
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -81,7 +81,7 @@ Then we define `rpc` methods inside our service definition, specifying their req
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -93,7 +93,7 @@ Then we define `rpc` methods inside our service definition, specifying their req
   ```proto
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -108,7 +108,7 @@ Then we define `rpc` methods inside our service definition, specifying their req
   ```proto
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/cpp.md
+++ b/content/docs/tutorials/basic/cpp.md
@@ -85,7 +85,7 @@ all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -99,7 +99,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -111,7 +111,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -126,7 +126,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/csharp.md
+++ b/content/docs/tutorials/basic/csharp.md
@@ -79,7 +79,7 @@ all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -93,7 +93,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -105,7 +105,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -120,7 +120,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our  `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/dart.md
+++ b/content/docs/tutorials/basic/dart.md
@@ -79,7 +79,7 @@ all of which are used in the `RouteGuide` service:
 
   ```proto
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -93,7 +93,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -105,7 +105,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -120,7 +120,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/go.md
+++ b/content/docs/tutorials/basic/go.md
@@ -82,7 +82,7 @@ all of which are used in the `RouteGuide` service:
 
   ```proto
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -96,7 +96,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -108,7 +108,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -123,7 +123,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our .proto file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/java.md
+++ b/content/docs/tutorials/basic/java.md
@@ -95,7 +95,7 @@ all of which are used in the `RouteGuide` service:
 
   ```proto
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -109,7 +109,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -121,7 +121,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -136,7 +136,7 @@ all of which are used in the `RouteGuide` service:
   ```proto
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/node.md
+++ b/content/docs/tutorials/basic/node.md
@@ -96,7 +96,7 @@ all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -110,7 +110,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -122,7 +122,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -137,7 +137,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/objective-c.md
+++ b/content/docs/tutorials/basic/objective-c.md
@@ -123,7 +123,7 @@ service method, all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *response-streaming RPC* where the client sends a request to the server and
@@ -135,7 +135,7 @@ service method, all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *request-streaming RPC* where the client sends a sequence of messages to the
@@ -147,7 +147,7 @@ service method, all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -162,7 +162,7 @@ service method, all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/php.md
+++ b/content/docs/tutorials/basic/php.md
@@ -113,7 +113,7 @@ service method, all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *response-streaming RPC* where the client sends a request to the server and
@@ -125,7 +125,7 @@ service method, all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *request-streaming RPC* where the client sends a sequence of messages to the
@@ -137,7 +137,7 @@ service method, all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -152,7 +152,7 @@ service method, all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/python.md
+++ b/content/docs/tutorials/basic/python.md
@@ -83,7 +83,7 @@ all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *response-streaming RPC* where the client sends a request to the server and
@@ -97,7 +97,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *request-streaming RPC* where the client writes a sequence of messages and
@@ -109,7 +109,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectionally-streaming RPC* where both sides send a sequence of messages
@@ -124,7 +124,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Your `.proto` file also contains protocol buffer message type definitions for all

--- a/content/docs/tutorials/basic/ruby.md
+++ b/content/docs/tutorials/basic/ruby.md
@@ -83,7 +83,7 @@ all of which are used in the `RouteGuide` service:
 
   ```protobuf
   // Obtains the feature at a given position.
-  rpc GetFeature(Point) returns (Feature) {}
+  rpc GetFeature(Point) returns (Feature);
   ```
 
 - A *server-side streaming RPC* where the client sends a request to the server
@@ -97,7 +97,7 @@ all of which are used in the `RouteGuide` service:
   // streamed rather than returned at once (e.g. in a response message with a
   // repeated field), as the rectangle may cover a large area and contain a
   // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  rpc ListFeatures(Rectangle) returns (stream Feature);
   ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages
@@ -109,7 +109,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of Points on a route being traversed, returning a
   // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  rpc RecordRoute(stream Point) returns (RouteSummary);
   ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages
@@ -124,7 +124,7 @@ all of which are used in the `RouteGuide` service:
   ```protobuf
   // Accepts a stream of RouteNotes sent while a route is being traversed,
   // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
   ```
 
 Our `.proto` file also contains protocol buffer message type definitions for all


### PR DESCRIPTION
Use a semicolon instead of an empty options list.

This is consistent with the style guide and examples and in the protobuf documentation:
- https://developers.google.com/protocol-buffers/docs/style#services
- https://developers.google.com/protocol-buffers/docs/proto3#services
- https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#service_definition
