### PR TITLE
Config: eliminate grpc_release_tag_no_v

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,6 @@ pygmentsCodeFences: true
 params:
   locale: en_US
   grpc_release_tag: v1.28.1
-  grpc_release_tag_no_v: 1.28.1
   grpc_java_release_tag: v1.29.0
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework

--- a/content/docs/quickstart/csharp.md
+++ b/content/docs/quickstart/csharp.md
@@ -142,7 +142,7 @@ to generate the code. Starting from version 1.17 the package also integrates wit
 MSBuild to provide [automatic C# code generation](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md)
 from `.proto` files.
 
-This example project already depends on the `Grpc.Tools.{{< param grpc_release_tag_no_v >}}` NuGet package so just re-building the solution
+This example project already depends on the `Grpc.Tools.{{< psubstr grpc_release_tag 1 >}}` NuGet package so just re-building the solution
 is enough to regenerate the code from our modified `.proto` file.
 
 You can rebuild just like we first built the original

--- a/layouts/shortcodes/psubstr.html
+++ b/layouts/shortcodes/psubstr.html
@@ -1,0 +1,14 @@
+{{/*
+  Param substring shortcode: psubstr PARAM_NAME START
+*/}}
+{{- $name := (.Get 0) -}}
+{{ $start := (.Get 1) -}}
+{{ with $name -}}
+  {{ with ($.Page.Param .) -}}
+    {{ substr . $start -}}
+  {{ else -}}
+    {{ errorf "Param %q not found: %s" $name $.Position -}}
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Missing param key: %s" $.Position -}}
+{{ end -}}


### PR DESCRIPTION
Use custom substring shortcode based on buildin `param` shortcode.

Generates same site content as before this PR. /cc @lucperkins 