### PR TITLE
C# tutorial: Simplify instructions for running route guide server and client

### DIFF
--- a/content/docs/languages/csharp/basics.md
+++ b/content/docs/languages/csharp/basics.md
@@ -481,15 +481,15 @@ Using `dotnet` command line tool
 Run the server:
 
 ```sh
-> cd RouteGuideServer/bin/Debug/netcoreapp2.1
-> dotnet exec RouteGuideServer.dll
+> cd RouteGuideServer
+> dotnet run
 ```
 
 From a different terminal, run the client:
 
 ```sh
-> cd RouteGuideClient/bin/Debug/netcoreapp2.1
-> dotnet exec RouteGuideClient.dll
+> cd RouteGuideClient
+> dotnet run
 ```
 
 You can also run the server and client directly from Visual Studio.


### PR DESCRIPTION
The original issue: https://github.com/grpc/grpc/issues/22157

The PR that enables simplified running of the example: https://github.com/grpc/grpc/pull/22930

This should only be merged once grpc 1.30.x is released (and the updated example is on the release branch).