### PR TITLE
Curate homepage CTA buttons

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -142,15 +142,9 @@ menu:
       parent: guides
 
   buttons:
-    - name: Quick Start
-      url: /docs/quickstart
+    - name: Learn more
+      url: /docs/guides
       weight: 1
-    - name: Docs
-      url: /docs
+    - name: Get started
+      url: /docs/quickstart
       weight: 2
-    - name: Concepts
-      url: /docs/guides/concepts
-      weight: 3
-    - name: Community
-      url: /community
-      weight: 4


### PR DESCRIPTION
Before this PR the homepage Call-To-Action (CTA) buttons were:

> <img src="https://user-images.githubusercontent.com/4140793/82091196-ef411e00-96c4-11ea-9452-ed3938a58653.png" height=50>

This PR simplifies the CTA buttons to be:

> <img src="https://user-images.githubusercontent.com/4140793/82091241-fff19400-96c4-11ea-9709-5537e066254f.png" height=50>

**Preview**: https://deploy-preview-223--grpc-io.netlify.app

Comments:
- Dropped "Docs" and "Community" CTA buttons because they are accessible from the top nav
- "Learn more" references the "What is gRPC" page
- Contributes to #224

cc @thisisnotapril @zacharysarah @lucperkins 