### PR TITLE
CTA button cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,11 +117,3 @@ menu:
       url: /faq
       weight: 7
       parent: docs
-
-  buttons:
-    - name: Learn more
-      url: /docs/guides
-      weight: 1
-    - name: Get started
-      url: /docs/quickstart
-      weight: 2

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -10,11 +10,12 @@
       <br />
 
       <div class="buttons are-medium is-centered">
-        {{ range site.Menus.buttons }}
-        <a class="button is-primary has-text-weight-bold" href="{{ .URL }}">
-          {{ .Name }}
+        <a class="button is-primary has-text-weight-bold" href="/docs/guides">
+          Learn more
         </a>
-        {{ end }}
+        <a class="button is-primary has-text-weight-bold" href="/docs/quickstart">
+          Get started
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Followup to #223 - simplify the homepage hero section by just using plain HTML for the CTA buttons (there's no benefit to the data-driven generation of these two buttons).