### PR TITLE
Left-nav: support 3 levels, drop TOC and some cleanup

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -166,7 +166,6 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
   .is-main
     flex: 1
 
-  
 .is-feature-pane
   margin-bottom: 2rem
 
@@ -246,7 +245,7 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
       li.nav-section-link
         font-size: 1.1rem
 
-        &.is-active
+        & .is-active
           +active
 
         & + li.nav-section-link

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,16 +1,16 @@
-{{ $here           := .RelPermalink }}
-{{ $currentSection := .CurrentSection }}
+{{ $here           := .RelPermalink -}}
+{{ $currentSection := .CurrentSection -}}
 {{ $docSections := (index (where site.Sections "Section" "docs") 0).Sections -}}
 
 <div class="nav is-sticky">
-  {{ range $docSections }}
+  {{ range $docSections -}}
   {{ $children := .RegularPages -}}
   {{ if eq .Params.nav_children "none" -}}
     {{ $children = false -}}
   {{ else if hasPrefix .Params.nav_children "section" -}}
     {{ $children = .Sections -}}
   {{ end -}}
-  {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink }}
+  {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink -}}
   <div class="nav-section" x-data="{ open: {{ $isThisSection }} }">
     {{ $isActive := (or $isThisSection (eq $here .RelPermalink)) -}}
     {{ $title := .Params.short | default .Title | upper -}}
@@ -21,20 +21,20 @@
         </a>
       </div>
 
-      {{ if $children }}
+      {{ if $children -}}
       <div class="level-right">
         <span class="level-item" @click="open = !open">
           <i class="fas has-text-grey" :class="{ 'fa-chevron-down': !open, 'fa-chevron-up': open }"></i>
         </span>
       </div>
-      {{ end }}
+      {{ end -}}
     </nav>
 
-    {{ with $children }}
+    {{ with $children -}}
     <ul class="nav-section-links" x-show="open">
-      {{ range . }}
+      {{ range . -}}
       {{ $children := .RegularPages -}}
-      {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink }}
+      {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink -}}
       {{ $isActive := eq $here .RelPermalink -}}
       {{ if $children -}}
         {{ $isActive = or $isActive $isThisSection -}}
@@ -46,30 +46,30 @@
               {{ .Params.short | default .Title }}
             </a>
           </div>
-          {{ if $children }}
+          {{ if $children -}}
             <div class="level-right">
               <span class="level-item" @click="open = !open">
                 <i class="fas has-text-grey" :class="{ 'fa-chevron-down': !open, 'fa-chevron-up': open }"></i>
               </span>
             </div>
-          {{ end }}
+          {{ end -}}
         </nav>
-        {{ if $children }}
+        {{ if $children -}}
           <ul class="nav-section-links" x-show="open">
-            {{ range $children }}
+            {{ range $children -}}
               {{ $isActive := eq $here .RelPermalink -}}
               <li class="nav-section-link{{ if $isActive }} is-active{{ end }}">
                 <a href="{{ .RelPermalink }}">
                   {{ .Params.short | default .Title }}
                 </a>
               </li>
-            {{ end }}
+            {{ end -}}
           </ul>
-        {{ end }}
+        {{ end -}}
       </li>
-      {{ end }}
+      {{ end -}}
     </ul>
-    {{ end }}
+    {{ end -}}
   </div>
-  {{ end }}
+  {{ end -}}
 </div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -13,7 +13,7 @@
   {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink }}
   <div class="nav-section" x-data="{ open: {{ $isThisSection }} }">
     {{ $isActive := (or $isThisSection (eq $here .RelPermalink)) -}}
-    {{ $title := .Params.short | default .Title -}}
+    {{ $title := .Params.short | default .Title | upper -}}
     <nav class="level">
       <div class="level-left">
         <a class="nav-section-title is-size-5 is-size-6-mobile{{ if $isActive }} is-active{{ end }}" href="{{ .RelPermalink }}">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,21 +1,27 @@
 {{ $here           := .RelPermalink }}
-{{ $docsSections   := (index (where site.Sections "Section" "docs") 0).Sections }}
 {{ $currentSection := .CurrentSection }}
+{{ $docSections := (index (where site.Sections "Section" "docs") 0).Sections -}}
 
 <div class="nav is-sticky">
-  {{ range $docsSections }}
-  {{ $isThisSection := eq .CurrentSection.Title $currentSection.Title }}
+  {{ range $docSections }}
+  {{ $children := .RegularPages -}}
+  {{ if eq .Params.nav_children "none" -}}
+    {{ $children = false -}}
+  {{ else if hasPrefix .Params.nav_children "section" -}}
+    {{ $children = .Sections -}}
+  {{ end -}}
+  {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink }}
   <div class="nav-section" x-data="{ open: {{ $isThisSection }} }">
-    {{ $isHere := eq $here .RelPermalink }}
-    {{ $title := .Title | upper }}
+    {{ $isActive := (or $isThisSection (eq $here .RelPermalink)) -}}
+    {{ $title := .Params.short | default .Title -}}
     <nav class="level">
       <div class="level-left">
-        <a class="nav-section-title is-size-5 is-size-6-mobile{{ if $isHere }} is-active{{ end }}" href="{{ .RelPermalink }}">
+        <a class="nav-section-title is-size-5 is-size-6-mobile{{ if $isActive }} is-active{{ end }}" href="{{ .RelPermalink }}">
           {{ $title }}
         </a>
       </div>
 
-      {{ if .RegularPages }}
+      {{ if $children }}
       <div class="level-right">
         <span class="level-item" @click="open = !open">
           <i class="fas has-text-grey" :class="{ 'fa-chevron-down': !open, 'fa-chevron-up': open }"></i>
@@ -24,30 +30,43 @@
       {{ end }}
     </nav>
 
-    {{ with .RegularPages }}
+    {{ with $children }}
     <ul class="nav-section-links" x-show="open">
       {{ range . }}
-      {{ $isHere := eq $here .RelPermalink }}
-      {{ $title := cond (isset .Params "short") .Params.short .Title }}
-      <li class="nav-section-link{{ if $isHere }} is-active{{ end }}">
-        <a href="{{ .RelPermalink }}">
-          {{ if $isHere }}
-          <span class="icon has-text-secondary">
-            <i class="fas fa-arrow-right"></i>
-          </span>
+      {{ $children := .RegularPages -}}
+      {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink }}
+      {{ $isActive := eq $here .RelPermalink -}}
+      {{ if $children -}}
+        {{ $isActive = or $isActive $isThisSection -}}
+      {{ end -}}
+      <li class="nav-section-link" x-data="{ open: {{ $isThisSection }} }">
+        <nav class="level">
+          <div class="level-left{{ if $isActive }} is-active{{ end }}">
+            <a href="{{ .RelPermalink }}">
+              {{ .Params.short | default .Title }}
+            </a>
+          </div>
+          {{ if $children }}
+            <div class="level-right">
+              <span class="level-item" @click="open = !open">
+                <i class="fas has-text-grey" :class="{ 'fa-chevron-down': !open, 'fa-chevron-up': open }"></i>
+              </span>
+            </div>
           {{ end }}
-
-          {{ $title }}
-        </a>
+        </nav>
+        {{ if $children }}
+          <ul class="nav-section-links" x-show="open">
+            {{ range $children }}
+              {{ $isActive := eq $here .RelPermalink -}}
+              <li class="nav-section-link{{ if $isActive }} is-active{{ end }}">
+                <a href="{{ .RelPermalink }}">
+                  {{ .Params.short | default .Title }}
+                </a>
+              </li>
+            {{ end }}
+          </ul>
+        {{ end }}
       </li>
-      
-      {{ if $isHere }}
-      {{ if gt (len .TableOfContents) 32 }}
-      <div class="nav-section-toc">
-        {{ .TableOfContents }}
-      </div>
-      {{ end }}
-      {{ end }}
       {{ end }}
     </ul>
     {{ end }}


### PR DESCRIPTION
- Support 3 levels in the left-nav
- Remove TOC from left-nav - contributes to #231
- Show ancestor left-nav entries as active when a subpage is active
