### PR TITLE
Drop `layout` front-matter entry from docs pages

### DIFF
--- a/content/docs/guides/auth.md
+++ b/content/docs/guides/auth.md
@@ -1,5 +1,4 @@
 ---
-layout: guides
 title: Authentication
 description: >
   An overview of gRPC authentication, including built-in auth mechanisms, and

--- a/content/docs/guides/benchmarking.md
+++ b/content/docs/guides/benchmarking.md
@@ -1,5 +1,4 @@
 ---
-layout: guides
 title: Benchmarking
 description: |
   gRPC is designed to support high-performance open-source RPCs in many languages. This document describes the performance benchmarking tools, the scenarios considered by the tests, and the testing infrastructure.
@@ -14,7 +13,7 @@ workflow. Multi-language performance tests run hourly against
 the master branch, and these numbers are reported to a dashboard for
 visualization.
 
-  * [Multi-language performance dashboard @latest_release (lastest available stable release)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5636470266134528) 
+  * [Multi-language performance dashboard @latest_release (lastest available stable release)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5636470266134528)
   * [Multi-language performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584)
   * [C++ detailed performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5685265389584384)
 
@@ -63,7 +62,7 @@ server implementation without testing the other side.
 Although PHP or mobile environments do not support a gRPC server
 (which is needed for our performance tests), their client-side
 performance can be benchmarked using a proxy WorkerService written in
-another language. This code is implemented for PHP but is not yet in 
+another language. This code is implemented for PHP but is not yet in
 continuous testing mode.
 
 ### Scenarios under test

--- a/content/docs/guides/concepts.md
+++ b/content/docs/guides/concepts.md
@@ -1,5 +1,4 @@
 ---
-layout: guides
 title: gRPC Concepts
 description: |-
   An introduction to key gRPC concepts, with an overview of gRPC architecture

--- a/content/docs/guides/contributing.md
+++ b/content/docs/guides/contributing.md
@@ -1,5 +1,4 @@
 ---
-layout: guides
 title: Contribution Guidelines
 ---
 

--- a/content/docs/guides/error.md
+++ b/content/docs/guides/error.md
@@ -1,5 +1,4 @@
 ---
-layout: guides
 title: Error Handling
 description: How gRPC deals with errors, and gRPC error codes.
 ---

--- a/content/docs/quickstart/android.md
+++ b/content/docs/quickstart/android.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Android Java Quickstart
 short: Android
 description: This guide gets you started with gRPC in Android Java with a simple working example.

--- a/content/docs/quickstart/cpp.md
+++ b/content/docs/quickstart/cpp.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: C++ Quick Start
 short: C++
 description: This guide gets you started with gRPC in C++ with a simple working example.

--- a/content/docs/quickstart/csharp-dotnet.md
+++ b/content/docs/quickstart/csharp-dotnet.md
@@ -1,6 +1,5 @@
 ---
 title: C# Quick Start (for the "grpc-dotnet" implementation)
-layout: quickstart
 short: C# with grpc-dotnet
 description: This guide gets you started with gRPC for .NET with a simple working example.
 ---

--- a/content/docs/quickstart/csharp.md
+++ b/content/docs/quickstart/csharp.md
@@ -1,6 +1,5 @@
 ---
 title: C# Quick Start
-layout: quickstart
 short: C#
 description: This guide gets you started with gRPC in C# with a simple working example.
 ---

--- a/content/docs/quickstart/dart.md
+++ b/content/docs/quickstart/dart.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Dart Quick Start
 short: Dart
 description: This guide gets you started with gRPC in Dart with a simple working example.

--- a/content/docs/quickstart/go.md
+++ b/content/docs/quickstart/go.md
@@ -1,6 +1,5 @@
 ---
 title: Go Quick Start
-layout: quickstart
 short: Go
 description: This guide gets you started with gRPC in Go with a simple working example.
 ---

--- a/content/docs/quickstart/java.md
+++ b/content/docs/quickstart/java.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Java Quick Start
 short: Java
 description: This guide gets you started with gRPC in Java with a simple working example.

--- a/content/docs/quickstart/kotlin.md
+++ b/content/docs/quickstart/kotlin.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Kotlin/JVM Quick Start
 short: Kotlin/JVM
 description: This guide gets you started with gRPC in Kotlin with a simple working example.

--- a/content/docs/quickstart/node.md
+++ b/content/docs/quickstart/node.md
@@ -1,6 +1,5 @@
 ---
 title: Node Quick Start
-layout: quickstart
 short: Node
 description: This guide gets you started with gRPC in Node with a simple working example.
 ---

--- a/content/docs/quickstart/objective-c.md
+++ b/content/docs/quickstart/objective-c.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Objective-C Quick Start
 short: Objective-C
 description: This guide gets you started with gRPC on the iOS platform in Objective-C with a simple working example.

--- a/content/docs/quickstart/php.md
+++ b/content/docs/quickstart/php.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: PHP Quick Start
 short: PHP
 description: This guide gets you started with gRPC in PHP with a simple working example.

--- a/content/docs/quickstart/python.md
+++ b/content/docs/quickstart/python.md
@@ -1,5 +1,4 @@
 ---
-layout: quickstart
 title: Python Quick Start
 short: Python
 description: This guide gets you started with gRPC in Python with a simple working example.

--- a/content/docs/quickstart/ruby.md
+++ b/content/docs/quickstart/ruby.md
@@ -1,6 +1,5 @@
 ---
 title: Ruby Quick Start
-layout: quickstart
 short: Ruby
 description: This guide gets you started with gRPC in Ruby with a simple working example.
 ---

--- a/content/docs/quickstart/web.md
+++ b/content/docs/quickstart/web.md
@@ -1,6 +1,5 @@
 ---
 title: Web Quick Start
-layout: quickstart
 short: Web
 description: This guide gets you started with gRPC-Web with a simple working example.
 ---

--- a/content/docs/samples/_index.md
+++ b/content/docs/samples/_index.md
@@ -1,7 +1,6 @@
 ---
 bodyclass: docs
 headline: gRPC Samples
-layout: docs
 title: Samples
 weight: 5
 ---

--- a/content/docs/talks/_index.md
+++ b/content/docs/talks/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: docs
 title: Presentations & Talks
 short: Presentations
 weight: 6

--- a/content/docs/tutorials/_index.md
+++ b/content/docs/tutorials/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: Tutorials
 weight: 3
 ---

--- a/content/docs/tutorials/async/helloasync-cpp.md
+++ b/content/docs/tutorials/async/helloasync-cpp.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: Asynchronous Basics - C++
 short: Async - C++
 group: async

--- a/content/docs/tutorials/auth/oauth2-objective-c.md
+++ b/content/docs/tutorials/auth/oauth2-objective-c.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: OAuth2 on gRPC - Objective-C
 short: Auth - Objective-C
 group: auth

--- a/content/docs/tutorials/basic/android.md
+++ b/content/docs/tutorials/basic/android.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Android Java
 short: Android
 group: basic

--- a/content/docs/tutorials/basic/cpp.md
+++ b/content/docs/tutorials/basic/cpp.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - C++
 group: basic
 short: C++

--- a/content/docs/tutorials/basic/csharp.md
+++ b/content/docs/tutorials/basic/csharp.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - C#
 group: basic
 short: C#

--- a/content/docs/tutorials/basic/dart.md
+++ b/content/docs/tutorials/basic/dart.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Dart
 group: basic
 short: Dart

--- a/content/docs/tutorials/basic/go.md
+++ b/content/docs/tutorials/basic/go.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Go
 group: basic
 short: Go

--- a/content/docs/tutorials/basic/java.md
+++ b/content/docs/tutorials/basic/java.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Java
 group: basic
 short: Java

--- a/content/docs/tutorials/basic/kotlin.md
+++ b/content/docs/tutorials/basic/kotlin.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 group: basic
 title: gRPC Basics - Kotlin/JVM
 short: Kotlin/JVM

--- a/content/docs/tutorials/basic/node.md
+++ b/content/docs/tutorials/basic/node.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Node.js
 group: basic
 short: Node

--- a/content/docs/tutorials/basic/objective-c.md
+++ b/content/docs/tutorials/basic/objective-c.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Objective-C
 group: basic
 short: Objective-C

--- a/content/docs/tutorials/basic/php.md
+++ b/content/docs/tutorials/basic/php.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - PHP
 group: basic
 short: PHP

--- a/content/docs/tutorials/basic/python.md
+++ b/content/docs/tutorials/basic/python.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Python
 group: basic
 short: Python

--- a/content/docs/tutorials/basic/ruby.md
+++ b/content/docs/tutorials/basic/ruby.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Ruby
 group: basic
 short: Ruby

--- a/content/docs/tutorials/basic/web.md
+++ b/content/docs/tutorials/basic/web.md
@@ -1,5 +1,4 @@
 ---
-layout: tutorials
 title: gRPC Basics - Web
 group: basic
 short: Web


### PR DESCRIPTION
I've checked that the generated site isn't affected by the removal of these noop front-matter layout entries.