### PR TITLE
Go quick start: adjust protoc cmd line options

### DIFF
--- a/content/docs/languages/go/quickstart.md
+++ b/content/docs/languages/go/quickstart.md
@@ -129,7 +129,7 @@ Before you can use the new service method, you need to recompile the updated
 While still in the `examples/helloworld` directory, run the following command:
 
 ```sh
-$ protoc -I helloworld/ helloworld/helloworld.proto --go_out=plugins=grpc:helloworld
+$ protoc -I helloworld --go_out=plugins=grpc:helloworld --go_opt=paths=source_relative helloworld.proto
 ```
 
 This will regenerate the `helloworld/helloworld.pb.go` file, which contains:

--- a/content/docs/languages/go/quickstart.md
+++ b/content/docs/languages/go/quickstart.md
@@ -129,7 +129,7 @@ Before you can use the new service method, you need to recompile the updated
 While still in the `examples/helloworld` directory, run the following command:
 
 ```sh
-$ protoc -I helloworld --go_out=plugins=grpc:helloworld --go_opt=paths=source_relative helloworld.proto
+$ protoc --go_out=plugins=grpc:. --go_opt=paths=source_relative helloworld/helloworld.proto
 ```
 
 This will regenerate the `helloworld/helloworld.pb.go` file, which contains:


### PR DESCRIPTION
Since the last update to the Go quick start, the following option was added to the example's `helloworld.proto` file:

```proto
option go_package = "google.golang.org/grpc/examples/helloworld/helloworld";
```

This PR ensures that the generated `.pb.go` file ends up in the example's local `helloworld` folder.

Closes #236