### PR TITLE
Drop contributing.md placeholder file

### DIFF
--- a/content/docs/guides/contributing.md
+++ b/content/docs/guides/contributing.md
@@ -1,5 +1,0 @@
----
-title: Contribution Guidelines
----
-
-Coming soon!

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,3 +1,4 @@
+/docs/guides/contributing                 /community
 /docs/languages/csharp/quickstart-dotnet  /docs/languages/csharp/dotnet
 /docs/quickstart/csharp-dotnet            /docs/languages/csharp/dotnet
 /docs/reference                           /docs/languages


### PR DESCRIPTION
The Community page will hold the "contributing" information. This PR is in preparation for rework of the Guides section.