### PR TITLE
Support markdown in link text

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,2 +1,10 @@
-{{ $isRemote := hasPrefix .Destination "http" }}
-<a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text -}}{{ if $isRemote }}&nbsp;<sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}</a>
+{{ $isRemote := hasPrefix .Destination "http" -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $isRemote }} target="_blank" rel="noopener"{{ end -}}
+>
+  {{- .Text | safeHTML -}}
+  {{ if $isRemote -}}
+  &nbsp;<sup><i class="fas fa-external-link-alt"></i></sup>
+  {{- end -}}
+</a>


### PR DESCRIPTION
- Add back the `safeURL` transform.
- Add `rel="noopener"` for external links.

Followup to #247, which removed the `safeURL` transformation (I missed that in my review 🤷). W/o it we see link-text containing markdown as HTML like this (excerpt from [this page](https://grpc.io/docs/languages/cpp/async/#overview)):

> ![image](https://user-images.githubusercontent.com/4140793/83196840-8cab4180-a10a-11ea-9a33-2ea43b766312.png)

**Preview:** https://deploy-preview-251--grpc-io.netlify.app/docs/languages/cpp/async/#overview

cc @lucperkins 