### PR TITLE
Fix external link rendering and styling

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -301,3 +301,12 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
   h#{$i}
     &:hover > .headline-hash
       display: inline
+
+// Currently (2020-05-29), the external-link character is used as an icon in the
+// top navbar. The "a >" prefix is used in the next rule only as a simple means
+// of excluding the style changes from applying in that case.
+a > .fa-external-link-alt::before
+  font-size: 50%
+  margin-left: 3px
+  opacity: 0.8
+  vertical-align: top

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -5,6 +5,6 @@
 >
   {{- .Text | safeHTML -}}
   {{ if $isRemote -}}
-  &nbsp;<sup><i class="fas fa-external-link-alt"></i></sup>
+  <i class="fas fa-external-link-alt"></i>
   {{- end -}}
 </a>


### PR DESCRIPTION
This using CSS styling to format the external link icon, rather than HTML elements. In addition to improving the visuals, this gives a better UX when copy-pasting text that includes external links.

### Screenshots from the [Community](https://grpc.io/community) page

#### Before:

> ![image](https://user-images.githubusercontent.com/4140793/83305572-0d337600-a1cf-11ea-9d99-1b4ccf7df7cb.png)

Copy-paste (note the extra spaces before the commas):
> Or shortcut to C , C++ , Node.js , Python , Ruby , Objective-C , PHP , and C# .

#### After:

> ![image](https://user-images.githubusercontent.com/4140793/83305646-25a39080-a1cf-11ea-83fa-4dd98911951b.png)

Copy-paste:
> Or shortcut to C, C++, Node.js, Python, Ruby, Objective-C, PHP, and C#.

---

This PR leaves the currently styling as is for the top navbar (note the external-link icon after "PACKAGES"):

> ![image](https://user-images.githubusercontent.com/4140793/83305766-5daad380-a1cf-11ea-9d36-179b70256d77.png)
