### PR TITLE
Updates the grpc-web instructions to run the basic example

### DIFF
--- a/content/docs/languages/web/quickstart.md
+++ b/content/docs/languages/web/quickstart.md
@@ -19,8 +19,8 @@ This demo requires Docker Compose file
 ```sh
 $ git clone https://github.com/grpc/grpc-web
 $ cd grpc-web
-$ docker-compose pull
-$ docker-compose up -d node-server envoy commonjs-client
+$ docker-compose pull node-server envoy commonjs-client
+$ docker-compose up node-server envoy commonjs-client
 ```
 
 From your browser visit


### PR DESCRIPTION
Updates the docker commands that weren't working.
It is now like the ones at the repository: https://github.com/grpc/grpc-web