### PR TITLE
Fix side menu scrolling

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -214,6 +214,8 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
 .is-sticky
   +sticky
   top: $navbar-height + 3rem
+  height: 100vh
+  overflow-y: scroll
 
 .is-constrained
   max-width: 90ch
@@ -253,6 +255,9 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
 
     & + &
       margin-top: 1.5rem
+
+.level-right
+  margin-right: 0.75rem
 
 .blog-list
   ul


### PR DESCRIPTION
Closes #217 

This PR introduces a max-height for the side menu (determined by the viewport height) and forces the side menu overflow to scroll. It also introduces a small margin-right on the carets/arrows in the side menu, so that they don't overlap with the scrollbar.