### PR TITLE
Move official-support table to languages page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 ---
 title: About gRPC
-description: Who is using it, why they're using it, and which platforms support it
+description: Who is using gRPC and why
 ---
 
 gRPC is a modern open source high performance RPC framework that can run in any
@@ -33,10 +33,6 @@ Check out what people are saying below.
 
 {{< testimonials >}}
 
-## Officially supported languages and platforms
-
-{{< supported-platforms >}}
-
 ## The story behind gRPC
 
 Google has been using a single general-purpose RPC infrastructure called Stubby
@@ -52,3 +48,10 @@ for microservices inside and outside Google but also for last mile of computing
 
 For more background on why we created gRPC, see the [gRPC Motivation and Design
 Principles](/blog/principles) on the [gRPC blog](/blog).
+
+{{< note >}}
+  <a name="officially-supported-languages-and-platforms"></a>
+
+  Our table of **officially supported languages and platforms** has moved!
+  See [Supported languages and platforms](/docs/languages#official-support).
+{{< /note >}}

--- a/content/docs/languages/_index.md
+++ b/content/docs/languages/_index.md
@@ -5,7 +5,7 @@ weight: 2
 nav_children: section
 ---
 
-Each language / platform has links to the following pages and more:
+Each gRPC language / platform has links to the following pages and more:
 
 - Quick start
 - Tutorials
@@ -29,6 +29,6 @@ Select a language to get started:
 
 ### Official support
 
-These are the officially supported language, platform and OS versions:
+These are the officially supported gRPC language, platform and OS versions:
 
 {{< supported-platforms >}}

--- a/content/docs/languages/_index.md
+++ b/content/docs/languages/_index.md
@@ -26,3 +26,9 @@ Select a language to get started:
 - [Python](python)
 - [Ruby](ruby)
 - [Web](web)
+
+### Official support
+
+These are the officially supported language, platform and OS versions:
+
+{{< supported-platforms >}}


### PR DESCRIPTION
(As agreed during 20/06/01 Docs WG meeting.)

### Preview

- https://deploy-preview-266--grpc-io.netlify.app/about/#officially-supported-languages-and-platforms
- https://deploy-preview-266--grpc-io.netlify.app/docs/languages/#official-support
