### PR TITLE
gRPC Go officially supports Go 1.12+

### DIFF
--- a/data/platforms.yaml
+++ b/data/platforms.yaml
@@ -15,7 +15,7 @@
   compilers: [Dart 2.2+]
 - language: Go
   platforms: [Windows, Linux, Mac]
-  compilers: [Go 1.6+]
+  compilers: [Go 1.12+]
 - language: Java
   platforms: [Windows, Linux, Mac]
   compilers: [JDK 8 recommended (Gingerbread+ for Android)]


### PR DESCRIPTION
(I'm looking into reworking the table so that we can simply mention the last three major releases, as is mentioned in the [Go Quick start](https://grpc.io/docs/languages/go/quickstart/#prerequisites).)