### PR TITLE
gRPC-web quick start updates

### DIFF
--- a/content/docs/languages/web/quickstart.md
+++ b/content/docs/languages/web/quickstart.md
@@ -4,49 +4,93 @@ description: This guide gets you started with gRPC-Web with a simple working exa
 weight: 1
 ---
 
-
 ### Prerequisites
 
-- `docker`
-- `docker-compose`
+- Docker and `docker-compose` supporting [Docker Compose file version 3][dcfv3].
+  For installation instructions see [Install Compose][install].
 
-This demo requires Docker Compose file
-[version 3](https://docs.docker.com/compose/compose-file/). Please refer to
-[Docker website](https://docs.docker.com/compose/install/#install-compose) on how to install Docker.
+  [dcfv3]: https://docs.docker.com/compose/compose-file/compose-versioning
+  [install]: https://docs.docker.com/compose/install/#install-compose
+
+### Get the example code
+
+The example code is part of the [grpc-web][] repo.
+
+ 1. [Dowload the repo as a zip file][download] and unzip it, or clone
+    the repo:
+
+    ```sh
+    $ git clone https://github.com/grpc/grpc-web
+    ```
+
+ 2. Change to the repo's root directory:
+
+    ```sh
+    $ cd grpc-web
+    ```
 
 ### Run an Echo example from your browser!
 
-```sh
-$ git clone https://github.com/grpc/grpc-web
-$ cd grpc-web
-$ docker-compose pull
-$ docker-compose up -d node-server envoy commonjs-client
+From the `grpc-web` directory:
+
+ 1. Fetch required packages and tools:
+
+    ```sh
+    $ docker-compose pull
+    ```
+
+    {{< note >}}
+Getting the following warning? You can ignore it for the purpose of running the
+example app:
+
+```nocode
+WARNING: Some service image(s) must be built from source
 ```
+    {{< /note >}}
 
-From your browser visit
-[localhost:8081/echotest.html](http://localhost:8081/echotest.html).
+ 2. Launch services as background processes:
 
-To shutdown, run `docker-compose down`.
+    ```sh
+    $ docker-compose up -d node-server envoy commonjs-client
+    ```
 
+ 3. From your browser:
+
+    - Visit
+    [localhost:8081/echotest.html](http://localhost:8081/echotest.html).
+    - Enter a message, like "Hello", in the text-input box.
+    - Press the **Send** button.
+
+    You'll see your message echoed by the server below the input box.
+
+Congratulations! You've just run a client-server application with gRPC.
+
+Once you are done, shutdown the services that you launched earlier by running
+the following command:
+
+```sh
+$ docker-compose down
+```
 
 ### What is happening?
 
-In this demo, there are three key components:
+This example app has three key components:
 
- 1. `node-server`: This is a standard gRPC Server, implemented in Node. This
-    server listens at port `:9090` and implements the service's business logic.
-
- 2. `envoy`: This is the Envoy proxy. It listens at `:8080` and forwards the
-    browser's gRPC-Web requests to port `:9090`. This is done via a config file
-    `envoy.yaml`.
-
- 3. `commonjs-client`: This component generates the client stub class using the
+ 1. `node-server` is a standard gRPC server, implemented in Node. This server
+    listens at port `:9090`, and implements the app's business logic (echoing
+    client messages).
+ 2. `envoy` is the Envoy proxy. It listens at `:8080` and forwards the browser's
+    gRPC-Web requests to port `:9090`.
+ 3. `commonjs-client`: this component generates the client stub class using the
     `protoc-gen-grpc-web` protoc plugin, compiles all the JS dependencies using
-    `webpack`, and hosts the static content `echotest.html` and `dist/main.js`
-    using a simple web server at port `:8081`. Once the user interacts with the
-    webpage, it sends a gRPC-Web request to the Envoy proxy endpoint at `:8080`.
-
+    `webpack`, and hosts the static content (`echotest.html` and `dist/main.js`)
+    at port `:8081` using a simple web server. User messages entered from the
+    webpage are sent to the Envoy proxy as gRPC-web requests.
 
 ### What's next
 
-- Work through a more detailed tutorial in [gRPC Basics: Web](/docs/tutorials/basic/web/).
+- Work through a more detailed tutorial in [gRPC Basics:
+  Web](/docs/tutorials/basic/web/).
+
+[grpc-web]: https://github.com/grpc/grpc-web
+[download]: https://github.com/grpc/grpc-web/archive/master.zip


### PR DESCRIPTION
The gRPC-web quick start page deviates from the other quick start pages in that it uses an Echo example rather than Hello World, but that might be ok for now. In any case, here are updates to the page.