### PR TITLE
Add "Daily builds" links for wrapped languages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,9 +81,6 @@ menu:
     - name: Community
       url: /community
       weight: 5
-    - name: Packages
-      url: https://packages.grpc.io
-      weight: 6
     - name: Overview
       url: /docs
       weight: 1

--- a/content/docs/languages/csharp/_index.md
+++ b/content/docs/languages/csharp/_index.md
@@ -9,6 +9,7 @@ core-library][core-library] implementation is covered here:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [API reference](api/{{< param api_path >}})
+- [Daily builds](daily-builds)
 
 For details concerning the newer gRPC for .NET implementation, see [gRPC for
 .NET](dotnet).

--- a/content/docs/languages/csharp/daily-builds.md
+++ b/content/docs/languages/csharp/daily-builds.md
@@ -1,0 +1,5 @@
+---
+title: Daily builds
+weight: 90
+# Note: this is a placeholder page. The URL to this page redirects elsewhere.
+---

--- a/content/docs/languages/php/_index.md
+++ b/content/docs/languages/php/_index.md
@@ -8,3 +8,4 @@ These language-specific pages are available:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [API reference](api/{{< param api_path >}})
+- [Daily builds](daily-builds)

--- a/content/docs/languages/php/daily-builds.md
+++ b/content/docs/languages/php/daily-builds.md
@@ -1,0 +1,5 @@
+---
+title: Daily builds
+weight: 90
+# Note: this is a placeholder page. The URL to this page redirects elsewhere.
+---

--- a/content/docs/languages/python/_index.md
+++ b/content/docs/languages/python/_index.md
@@ -8,3 +8,4 @@ These language-specific pages are available:
 - [Basics tutorial](basics)
 - [Generated-code reference](generated-code)
 - [API reference](api)
+- [Daily builds](daily-builds)

--- a/content/docs/languages/python/daily-builds.md
+++ b/content/docs/languages/python/daily-builds.md
@@ -1,0 +1,5 @@
+---
+title: Daily builds
+weight: 90
+# Note: this is a placeholder page. The URL to this page redirects elsewhere.
+---

--- a/content/docs/languages/ruby/_index.md
+++ b/content/docs/languages/ruby/_index.md
@@ -8,3 +8,4 @@ These language-specific pages are available:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [API reference](api/{{< param api_path >}})
+- [Daily builds](daily-builds)

--- a/content/docs/languages/ruby/daily-builds.md
+++ b/content/docs/languages/ruby/daily-builds.md
@@ -1,0 +1,5 @@
+---
+title: Daily builds
+weight: 90
+# Note: this is a placeholder page. The URL to this page redirects elsewhere.
+---

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,4 +1,5 @@
-{{ $isExternal := or (hasPrefix .Destination "http") (findRE "^(|../|/docs/languages/.+?/)api(/.*)?(\\?.*)?$" .Destination) -}}
+{{ $isRedirected := findRE "^(|../|/docs/languages/.+?/)(api|daily-builds)(/.*)?(\\?.*)?$" .Destination }}
+{{ $isExternal := or (hasPrefix .Destination "http") $isRedirected -}}
 <a href="{{ .Destination | safeURL }}"
   {{- with .Title }} title="{{ . }}"{{ end -}}
   {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -28,3 +28,7 @@
 
 # Base rule: API hosted on grpc.github.io
 /docs/languages/:lang/api/*  https://grpc.github.io/grpc/:lang/:splat 301!
+
+# Daily-build pages:
+
+/docs/languages/:_/daily-builds/*  https://packages.grpc.io 301!

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -59,7 +59,8 @@
             {{ range $children -}}
               {{ $isActive := eq $here .RelPermalink -}}
               {{ $isApi :=  findRE "^/docs/languages/.+?/api(/.*)?(\\?.*)?$" .RelPermalink -}}
-              {{ $isExternal := or (hasPrefix .RelPermalink "http") $isApi -}}
+              {{ $isRedirected := findRE "/daily-builds/" .RelPermalink -}}
+              {{ $isExternal := or (hasPrefix .RelPermalink "http") $isApi $isRedirected -}}
               {{ $href := .RelPermalink -}}
               {{ if and $isApi .Parent.Params.api_path -}}
                 {{ $href = printf "%s%s" $href .Parent.Params.api_path -}}


### PR DESCRIPTION
- Remove "Packages" external link from main nav
- Add links to "Daily builds" for relevant wrapped languages.
- Closes #255

Preview:
- https://deploy-preview-283--admiring-torvalds-f1ffea.netlify.app/docs/languages/csharp/
- https://deploy-preview-283--admiring-torvalds-f1ffea.netlify.app/docs/languages/python/
- ...

### Screenshot

> ![image](https://user-images.githubusercontent.com/4140793/84687245-67407500-af0b-11ea-912f-94577efddc1e.png)


(As discussed during 2020/06/01 Docs WG meeting)
