### PR TITLE
Announce gRPC Conf 2020 on every page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,8 @@ params:
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework
 
+  show_banner: true
+
   social:
     gitter: https://gitter.im/grpc/grpc
     reddit: https://www.reddit.com/r/grpc

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,7 @@
   <body class="is-page has-navbar-fixed-top">
     <main class="is-main">
       {{ partial "navbar.html" . }}
+      {{ partial "banner.html" -}}
       {{ block "main" . }}
       {{ end }}
     </main>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,0 +1,17 @@
+{{ if site.Params.show_banner -}}
+<div class="hero-head">
+  <div class="notification is-warning has-text-centered">
+    <p>
+      <a href="https://events.linuxfoundation.org/grpc-conf/register/" target="_blank" rel="noopener">
+        Register now
+        {{- partial "external-link.html" -}}
+      </a>
+      for the all virtual
+      <a href="https://events.linuxfoundation.org/grpc-conf" target="_blank" rel="noopener">
+        <strong>gRPC Conf 2020</strong>
+        {{- partial "external-link.html" -}}
+      </a>, July 27-28!
+    </p>
+  </div>
+</div>
+{{ end -}}

--- a/layouts/partials/external-link.html
+++ b/layouts/partials/external-link.html
@@ -1,0 +1,1 @@
+<i class="fas fa-external-link-alt"></i>


### PR DESCRIPTION
- Closes #281
- Setting `show_banner` to false in the config, generates the exact same site content as before this PR.

### Screenshots

- Mobile:
  <img width="337" alt="Screen Shot 2020-06-15 at 15 34 53" src="https://user-images.githubusercontent.com/4140793/84698474-d921ba00-af1d-11ea-81b6-8136a57ef1b9.png">

- Desktop:
  <img width="1038" alt="Screen Shot 2020-06-15 at 15 35 08" src="https://user-images.githubusercontent.com/4140793/84698486-dc1caa80-af1d-11ea-9d46-315a897c7a15.png">

cc @mjpitz