### PR TITLE
Go quick start: clone/download v1.30.0-dev.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ params:
   locale: en_US
   grpc_release_tag: v1.28.1
   grpc_java_release_tag: v1.30.0
+  grpc_go_release_tag: v1.30.0-dev.1
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework
 

--- a/content/docs/languages/go/quickstart.md
+++ b/content/docs/languages/go/quickstart.md
@@ -39,7 +39,7 @@ The example code is part of the [grpc-go][] repo.
     the repo:
 
     ```sh
-    $ git clone https://github.com/grpc/grpc-go
+    $ git clone -b {{< param grpc_go_release_tag >}} https://github.com/grpc/grpc-go
     ```
 
  2. Change to the quick start example directory:
@@ -201,7 +201,7 @@ from the `examples/helloworld` directory:
 - Explore the gRPC Go core API in its [reference
   documentation](https://godoc.org/google.golang.org/grpc).
 
-[download]: https://github.com/grpc/grpc-go/archive/{{< param grpc_release_tag >}}.zip
+[download]: https://github.com/grpc/grpc-go/archive/{{< param grpc_go_release_tag >}}.zip
 [Getting Started]: https://golang.org/doc/install
 [Go]: https://golang.org
 [grpc-go]: https://github.com/grpc/grpc-go


### PR DESCRIPTION
Closes #296. I've run through the quick start (using v1.30.0-dev.1) and it works fine.