### PR TITLE
Simplify API reference URL design and redirect handling

### DIFF
--- a/content/docs/languages/android/_index.md
+++ b/content/docs/languages/android/_index.md
@@ -7,4 +7,4 @@ These language-specific pages are available:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/csharp/_index.md
+++ b/content/docs/languages/csharp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: C# / .NET
-api_path: api/Grpc.Core
+api_path: grpc/LANG/api/Grpc.Core
 ---
 
 There are two official implementations of gRPC for C#. The original [gRPC

--- a/content/docs/languages/csharp/_index.md
+++ b/content/docs/languages/csharp/_index.md
@@ -8,7 +8,7 @@ core-library][core-library] implementation is covered here:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)
 - [Daily builds](daily-builds)
 
 For details concerning the newer gRPC for .NET implementation, see [gRPC for

--- a/content/docs/languages/csharp/dotnet.md
+++ b/content/docs/languages/csharp/dotnet.md
@@ -8,7 +8,7 @@ The following pages cover the C# implementation of gRPC for .NET
 
 - [Introduction to gRPC on .NET Core](https://docs.microsoft.com/aspnet/core/grpc)
 - [Tutorial: Create a gRPC client and server in ASP.NET Core][tutorial]
-- [API reference](../api/grpc/csharp-dotnet/api/Grpc.Core)
+- [API reference](api)
 
 Several sample applications are available from the [examples][] folder in the
 [grpc-dotnet][] repository.

--- a/content/docs/languages/dart/_index.md
+++ b/content/docs/languages/dart/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Dart
-api_path: pub.dev/documentation/grpc?ext=1
+api_path: https://pub.dev/documentation/grpc
 ---
 
 These language-specific pages are available:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/go/_index.md
+++ b/content/docs/languages/go/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Go
-api_path: pkg.go.dev/google.golang.org/grpc?ext=1
+api_path: https://pkg.go.dev/google.golang.org/grpc
 ---
 
 These language-specific pages are available:
@@ -8,4 +8,4 @@ These language-specific pages are available:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [Generated-code reference](generated-code)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/java/_index.md
+++ b/content/docs/languages/java/_index.md
@@ -8,4 +8,4 @@ These language-specific pages are available:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [Generated-code reference](generated-code)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/kotlin/_index.md
+++ b/content/docs/languages/kotlin/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Kotlin/JVM
-api_path: javadocs.dev/io.grpc/grpc-kotlin-stub/latest?ext=1
+api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
 ---
 
 These language-specific pages are available:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/objective-c/_index.md
+++ b/content/docs/languages/objective-c/_index.md
@@ -8,4 +8,4 @@ These language-specific pages are available:
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
 - [OAuth2 tutorial](oauth2)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)

--- a/content/docs/languages/php/_index.md
+++ b/content/docs/languages/php/_index.md
@@ -1,6 +1,6 @@
 ---
 title: PHP
-api_path: namespace-Grpc
+api_path: grpc/LANG/namespace-Grpc
 ---
 
 These language-specific pages are available:

--- a/content/docs/languages/php/_index.md
+++ b/content/docs/languages/php/_index.md
@@ -7,5 +7,5 @@ These language-specific pages are available:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)
 - [Daily builds](daily-builds)

--- a/content/docs/languages/ruby/_index.md
+++ b/content/docs/languages/ruby/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Ruby
-api_path: rubydoc.info/gems/grpc?ext=1
+api_path: https://rubydoc.info/gems/grpc
 ---
 
 These language-specific pages are available:
 
 - [Quick start](quickstart)
 - [Basics tutorial](basics)
-- [API reference](api/{{< param api_path >}})
+- [API reference](api)
 - [Daily builds](daily-builds)

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,21 +1,33 @@
+#
 # API reference docs
+#
 
-# API docs hosted on an external site other than grpc.github.io
-/docs/languages/:_/api/* ext=:_  https://:splat
+{{ range (.Site.GetPage "/docs/languages").Sections -}}
+  {{ $from_path := printf "/%sapi" .Dir -}}
 
-# API hosted on grpc.github.io using path indicated by splat
-/docs/languages/:_/api/grpc/*  https://grpc.github.io/grpc/:splat
-/docs/languages/:_/api/grpc-*  https://grpc.github.io/grpc-:splat
+  {{ $lang := path.Base .Dir -}}
+  {{ $to_url := .Params.api_path | default "" -}}
+  {{ if not (or (hasPrefix $to_url "grpc") (hasPrefix $to_url "http")) -}}
+    {{ $to_url = printf "grpc/%s/%s" $lang $to_url -}}
+  {{ end -}}
+  {{ if not (hasPrefix $to_url "http") -}}
+    {{ $to_url = printf "https://grpc.github.io/%s" $to_url -}}
+  {{ end -}}
 
-# Base rule: API hosted on grpc.github.io
-/docs/languages/:lang/api/*  https://grpc.github.io/grpc/:lang/:splat 301!
+  {{ printf "%-33s" $from_path }}  {{ $to_url }} 301!
+{{ end -}}
 
+# C# .NET
+/docs/languages/csharp/dotnet/api  https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Core
+
+#
 # Daily-build pages:
+#
 
 /docs/languages/:_/daily-builds/*  https://packages.grpc.io 301!
 
 #
-# Redirects for the site org prior to 2020/06:
+# Redirects of the site org prior to 2020/06:
 #
 
 /docs/guides/concepts                     /docs/what-is-grpc/core-concepts

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,17 +1,21 @@
 #
 # API reference docs
 #
+# Redirects are handled as if by the following rules (let $api_path be the
+# language page `api_path` param):
+#
+#  /docs/languages/:lang/api  https://grpc.github.io/grpc/:lang 301!  # when $api_path isn't given
+#  /docs/languages/:lang/api  $api_path 301!                          # when $api_path starts with 'http'
+#  /docs/languages/:lang/api  https://grpc.github.io/$api_path 301!   # otherwise; 'LANG' in $api_path is replaced by :lang
 
 {{ range (.Site.GetPage "/docs/languages").Sections -}}
   {{ $from_path := printf "/%sapi" .Dir -}}
 
-  {{ $lang := path.Base .Dir -}}
-  {{ $to_url := .Params.api_path | default "" -}}
-  {{ if not (or (hasPrefix $to_url "grpc") (hasPrefix $to_url "http")) -}}
-    {{ $to_url = printf "grpc/%s/%s" $lang $to_url -}}
-  {{ end -}}
-  {{ if not (hasPrefix $to_url "http") -}}
-    {{ $to_url = printf "https://grpc.github.io/%s" $to_url -}}
+  {{ $api_path := .Params.api_path | default "grpc/LANG" -}}
+  {{ $to_url := $api_path -}}
+  {{ if not (hasPrefix $api_path "http") -}}
+    {{ $api_path = replace $api_path "LANG" (path.Base .Dir) -}}
+    {{ $to_url = printf "https://grpc.github.io/%s" $api_path -}}
   {{ end -}}
 
   {{ printf "%-33s" $from_path }}  {{ $to_url }} 301!

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -9,12 +9,12 @@
 #  /docs/languages/:lang/api  https://grpc.github.io/$api_path 301!   # otherwise; 'LANG' in $api_path is replaced by :lang
 
 {{ range (.Site.GetPage "/docs/languages").Sections -}}
-  {{ $from_path := printf "/%sapi" .Dir -}}
+  {{ $from_path := printf "/%sapi" .File.Dir -}}
 
   {{ $api_path := .Params.api_path | default "grpc/LANG" -}}
   {{ $to_url := $api_path -}}
   {{ if not (hasPrefix $api_path "http") -}}
-    {{ $api_path = replace $api_path "LANG" (path.Base .Dir) -}}
+    {{ $api_path = replace $api_path "LANG" (path.Base .File.Dir) -}}
     {{ $to_url = printf "https://grpc.github.io/%s" $api_path -}}
   {{ end -}}
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -58,15 +58,10 @@
           <ul class="nav-section-links" x-show="open">
             {{ range $children -}}
               {{ $isActive := eq $here .RelPermalink -}}
-              {{ $isApi :=  findRE "^/docs/languages/.+?/api(/.*)?(\\?.*)?$" .RelPermalink -}}
-              {{ $isRedirected := findRE "/daily-builds/" .RelPermalink -}}
-              {{ $isExternal := or (hasPrefix .RelPermalink "http") $isApi $isRedirected -}}
-              {{ $href := .RelPermalink -}}
-              {{ if and $isApi .Parent.Params.api_path -}}
-                {{ $href = printf "%s%s" $href .Parent.Params.api_path -}}
-              {{ end -}}
+              {{ $isRedirected :=  findRE "^/docs/languages/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
+              {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
               <li class="nav-section-link{{ if $isActive }} is-active{{ end }}">
-                <a href="{{ $href }}"
+                <a href="{{ .RelPermalink }}"
                   {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}
                 >
                   {{- .Params.short | default .Title -}}


### PR DESCRIPTION
For any given language, LANG, the link to it's API reference document is now simply `/docs/languages/LANG/api`. This will make it much easier to link into the API docs, at the cost of more complex redirection rules, but I think that it is a good tradeoff.

Closes #288