### PR TITLE
Java basics tutorial: wrong path on cd command example

### DIFF
--- a/content/docs/languages/java/basics.md
+++ b/content/docs/languages/java/basics.md
@@ -52,7 +52,7 @@ $ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-
 Then change your current directory to `grpc-java/examples`:
 
 ```sh
-$ cd grpc-java/examples/routeguide
+$ cd grpc-java/examples
 ```
 
 ### Defining the service


### PR DESCRIPTION
Hey, I was following the java-grpc 'basics tutorial' doc and I found an issue. 

**context**: There isn't a folder named _routeguide_ inside the examples folder. 
**solution**: Path is fixed!