### PR TITLE
Revert grpc-go version so quick start works

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ params:
   locale: en_US
   grpc_release_tag: v1.30.0
   grpc_java_release_tag: v1.30.1
-  grpc_go_release_tag: v1.30.0
+  grpc_go_release_tag: v1.30.0-dev.1 # For context, see https://github.com/grpc/grpc.io/issues/298
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework
 


### PR DESCRIPTION
The version is currently only used in the quick start, and the instructions only work with v1.30.0-dev.1. We can update the grpc-go version once #298 is resolved.

Closes #306