### PR TITLE
Use new CNCF analytics id as default

### DIFF
--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,9 +1,11 @@
-{{ $id := "UA-60127042-1" }}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ $id }}"></script>
+{{ $cnfc_id := "UA-163836834-2" -}}
+{{ $google_id := "UA-60127042-1" -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ $cnfc_id }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '{{ $id }}');
+  gtag('config', '{{ $cnfc_id }}');
+  gtag('config', '{{ $google_id }}');
 </script>


### PR DESCRIPTION
Use new CNCF analytics ID as the default while still registering the previous ID.