### PR TITLE
Revert grpc-java release tag to version 1.30.1 because of Jcenter delays

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ pygmentsCodeFences: true
 params:
   locale: en_US
   grpc_release_tag: v1.30.0
-  grpc_java_release_tag: v1.30.2
+  grpc_java_release_tag: v1.30.1
   grpc_go_release_tag: v1.30.0
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework


### PR DESCRIPTION
fixes #317 (by undoing #309).

attn: @chalin 