### PR TITLE
Homepage: link directly to top quickstarts

### DIFF
--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -7,14 +7,33 @@
         {{ site.Params.description }}
       </p>
 
-      <br />
-
       <div class="buttons are-medium is-centered">
         <a class="button is-primary has-text-weight-bold" href="/docs/what-is-grpc/introduction">
           Learn more
         </a>
-        <a class="button is-primary has-text-weight-bold" href="/docs/quickstart">
-          Get started
+      </div>
+
+      <br />
+
+      <p class="title is-size-3 is-size-4-mobile">Get started!</p>
+      <div class="buttons are-medium is-centered">
+        <a class="button is-primary" href="/docs/languages/go/quickstart">
+          Go
+        </a>
+        <a class="button is-primary" href="/docs/languages/cpp/quickstart">
+          C++
+        </a>
+        <a class="button is-primary" href="/docs/languages/java/quickstart">
+          Java
+        </a>
+        <a class="button is-primary" href="/docs/languages/python/quickstart">
+          Python
+        </a>
+        <a class="button is-primary" href="/docs/languages/csharp/quickstart">
+          C#
+        </a>
+        <a class="button is-primary" href="/docs/languages">
+          <i class="fas fa-ellipsis-h"></i>
         </a>
       </div>
     </div>


### PR DESCRIPTION
- By adding the top 5 languages, about 75% of quick-start users will be able to link directly to their target pages
- Language quick-starts are ordered with the most visited first
- Closes #324

### Screenshots

> <img width="714" alt="Screen Shot 2020-06-29 at 11 30 47" src="https://user-images.githubusercontent.com/4140793/86026639-b0a9bd80-b9fd-11ea-83dc-78ecf4db4e7a.png">

> <img width="411" alt="Screen Shot 2020-06-29 at 11 30 33" src="https://user-images.githubusercontent.com/4140793/86026647-b3a4ae00-b9fd-11ea-9d26-43ff4baee630.png">

(Possible followup PR is to have the buttons be generated from a data file.)

cc @thisisnotapril @jtattermusch 