### PR TITLE
404 page rework, including title fix to the title

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ disableKinds: [taxonomy, taxonomyTerm]
 pygmentsCodeFences: true
 
 params:
+  repo: https://github.com/grpc/grpc.io
   locale: en_US
   grpc_release_tag: v1.30.0
   grpc_java_release_tag: v1.30.1

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,18 +1,19 @@
-{{ define "main" }}
-<section class="hero is-medium has-background-image">
+{{ define "title" -}}
+404 Page not found - {{ site.Title -}}
+{{ end -}}
+
+{{ define "main" -}}
+{{ $newIssuePath := "issues/new?title=Unexpected%20page-not-found%20error&body=URL%3A%20%0AExpected%20page%3A%20" -}}
+{{ $newIssueUrl := printf "%s/%s" site.Params.repo $newIssuePath -}}
+
+<section class="hero is-primary has-background-image">
   <div class="hero-body">
     <div class="container has-text-centered">
-      <p class="title is-size-1 is-size-2-mobile has-text-weight-bold is-spaced">
-        <span class="has-text-white">
-          404
-        </span>
-        <span class="has-text-secondary">
-          !
-        </span>
-      </p>
-
-      <p class="subtitle is-size-3 is-size-4-mobile has-text-grey-lighter has-text-weight-medium">
+      <p class="title is-size-1 is-size-2-mobile has-text-weight-bold">
         Page not found
+      </p>
+      <p class="subtitle is-size-3 is-size-4-mobile has-text-grey-lighter has-text-weight-medium">
+        404
       </p>
     </div>
   </div>
@@ -20,39 +21,23 @@
 
 <section class="section">
   <div class="container has-text-centered">
-    <div class="content has-bottom-padding is-medium">
+    <div class="content">
       <p>
-        Sorry, but that link wasn't found. Perhaps you were looking for one of the following:
+        The page that you requested doesn't exist.
       </p>
-
-      <a class="is-size-4 is-size-5-mobile" href="/">
-        Main page
-      </a>
-
-      <br />
-
-      <a class="is-size-4 is-size-5-mobile" href="/docs">
-        Documentation
-      </a>
-
-      <br />
-
-      <a class="is-size-4 is-size-5-mobile" href="/blog">
-        Blog
-      </a>
-
-      <br />
-
-      <a class="is-size-4 is-size-5-mobile" href="/community">
-        Community
-      </a>
-
-      <br />
-
-      <a class="is-size-4 is-size-5-mobile" href="/faq">
-        FAQ
-      </a>
+      <p>
+        Check the URL's spelling.
+      </p>
+      <p>
+        If you think that the page should exist,
+        <a href="{{ $newIssueUrl }}" target="_blank" rel="noopener">create an issue.</a>
+      </p>
+      <p>
+        <a class="button is-primary" href="/">
+          Homepage
+        </a>
+      </p>
     </div>
   </div>
 </section>
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
- Closes #329. Fix 404-page title so that we can find 404 pages more easily using analytics.
- Simplify page, and make it a bit more DRY -- avoid repeating links that are in main nav and footer.

### Screenshots

Before:
> <img width="352" alt="Screen Shot before" src="https://user-images.githubusercontent.com/4140793/86275264-ffdc2380-bba0-11ea-9fde-7bc9e5db60d1.png">

After:
> <img src="https://user-images.githubusercontent.com/4140793/86275363-24d09680-bba1-11ea-8792-a88f18625d11.png" width=400>
