### PR TITLE
Fix list item spacing

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -197,6 +197,11 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
   .highlight
     margin-bottom: 1rem
 
+  li >
+    p:last-child:not(:only-child),
+    ul:last-child:not(:only-child)
+      margin-bottom: 1em
+
   p a
     font-weight: $weight-medium
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,10 +5,6 @@ title: Documentation
 Learn about key gRPC concepts, try a quick start, find tutorials and reference
 material for all [supported languages](languages).
 
-<style>
-  div > ul > li { padding-top: 1em !important; }
-</style>
-
 - **New to gRPC?** Start with the following pages:
 
   - [Introduction to gRPC](what-is-grpc/introduction)


### PR DESCRIPTION
Fixes #305

### Screenshots

Compare the following with the screenshot in #305:

> ![image](https://user-images.githubusercontent.com/4140793/87174871-d492bc00-c2a5-11ea-9c14-5f25948f8fcf.png)

The `/docs` page even looks better now (we removed the in-page custom styling):

> ![image](https://user-images.githubusercontent.com/4140793/87175005-073cb480-c2a6-11ea-9c07-b56f50308d8d.png)
