### PR TITLE
🔗 Updated tutorials.md

### DIFF
--- a/content/docs/tutorials.md
+++ b/content/docs/tutorials.md
@@ -3,4 +3,4 @@ title: Tutorials
 ---
 
 Each language / platform has **tutorial** pages. Select a
-[language](/docs/languages) to view available tutorials.
+[language](/content/docs/languages) to view available tutorials.


### PR DESCRIPTION
The link was moved to reflect the nesting under `/content`