### PR TITLE
Style fix for anchor elements

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -203,8 +203,6 @@ $colors: mergeColorMaps(("secondary": ($secondary, $white), "twitter-blue": ($tw
       margin-bottom: 1em
 
   p a
-    font-weight: $weight-medium
-
     &:hover
       color: $secondary
 


### PR DESCRIPTION
Don't impose a fixed weight for all anchor elements, since it prevents anchor text from easily being shown in bold.

Before:

> <img src="https://user-images.githubusercontent.com/4140793/87233114-97582800-c392-11ea-8432-ace108254df2.png" width=400>

After:

> <img src="https://user-images.githubusercontent.com/4140793/87233126-b060d900-c392-11ea-967e-d15a5ff28cac.png" width=400>

