### PR TITLE
Dart quick start: fix path to examples

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,17 +1,20 @@
 {
-  "version": "0.1",
-  "language": "en",
-  // Workspace dictionary:
-  "words": [
-    "protoc",
-    "RPCs"
-  ],
-  "flagWords": [],
-  "ignoreWords": [
-    "codegen",
-    "grpc",
-    "proto",
-    "protos",
-    "routeguide"
-  ]
+    "version": "0.1",
+    "language": "en",
+    // Workspace dictionary:
+    "words": [
+        "protoc",
+        "RPCs",
+        "SDKs"
+    ],
+    "flagWords": [],
+    "ignoreWords": [
+        "codegen",
+        "grpc",
+        "helloworld",
+        "proto",
+        "protobuf",
+        "protos",
+        "routeguide"
+    ]
 }

--- a/content/docs/languages/dart/basics.md
+++ b/content/docs/languages/dart/basics.md
@@ -507,7 +507,7 @@ write in any order — the streams operate completely independently.
 Work from the example directory:
 
 ```sh
-$ cd examples/route_guide
+$ cd example/route_guide
 ```
 
 Get packages:

--- a/content/docs/languages/dart/quickstart.md
+++ b/content/docs/languages/dart/quickstart.md
@@ -2,6 +2,7 @@
 title: Quick Start
 description: This guide gets you started with gRPC in Dart with a simple working example.
 weight: 10
+spelling: cSpell:ignore Iprotos
 ---
 
 ### Prerequisites
@@ -48,7 +49,7 @@ The example code is part of the [grpc-dart][] repo.
  2. Change to the quick start example directory:
 
     ```sh
-    $ cd grpc-dart/examples/helloworld
+    $ cd grpc-dart/example/helloworld
     ```
 
 ### Run the example


### PR DESCRIPTION
Fixes #355