### PR TITLE
Docs top-nav menu: remove "Quick Start" and "Tutorial" entries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -97,14 +97,6 @@ menu:
       url: /docs/languages
       weight: 2
       parent: docs
-    - name: Quick Start
-      url: /docs/quickstart/
-      weight: 2
-      parent: docs
-    - name: Tutorials
-      url: /docs/tutorials/
-      weight: 3
-      parent: docs
     - name: Guides
       url: /docs/guides
       identifier: guides


### PR DESCRIPTION
Closes #358. As mentioned in #358, eliminating these entries should help reduce the number of visits to those pages. Eventually, we'll want to eliminate the pages too.