### PR TITLE
Banner update: Join us today at gRPC conf

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -3,11 +3,11 @@
   <div class="notification is-warning has-text-centered">
     <p>
       <a href="https://events.linuxfoundation.org/grpc-conf/register/" target="_blank" rel="noopener">
-        Register now
+        Join us <strong>today</strong>
         {{- partial "external-link.html" -}}
       </a>
-      for the all virtual
-      <a href="https://events.linuxfoundation.org/grpc-conf" target="_blank" rel="noopener">
+      at the all-virtual
+      <a href="https://events.linuxfoundation.org/grpc-conf/program/schedule/" target="_blank" rel="noopener">
         <strong>gRPC Conf 2020</strong>
         {{- partial "external-link.html" -}}
       </a>, July 27-28!


### PR DESCRIPTION
- Change leading banner text to read "Join us *today*"
- Change link to general conf page; instead link directly to schedule.

cc @thisisnotapril @ejona86

### Screenshot

> <img src="https://user-images.githubusercontent.com/4140793/88549059-dcfd2d80-cfed-11ea-802b-083ecf88dbc3.png" width=300>
