### PR TITLE
Update minimum API for Android Java

### DIFF
--- a/content/docs/languages/android/quickstart.md
+++ b/content/docs/languages/android/quickstart.md
@@ -7,7 +7,7 @@ weight: 10
 ### Prerequisites
 
 - [JDK][] version 7 or higher
-- Android SDK, API level 14 or higher
+- Android SDK, API level 16 or higher
 
    1. Install [Android Studio][] or the Android [command-line tools][].
 

--- a/data/platforms.yaml
+++ b/data/platforms.yaml
@@ -18,7 +18,7 @@
   compilers: [Go 1.12+]
 - language: Java
   platforms: [Windows, Linux, Mac]
-  compilers: [JDK 8 recommended (Gingerbread+ for Android)]
+  compilers: [JDK 8 recommended (Jelly Bean+ for Android)]
 - language: Kotlin/JVM
   platforms: [Windows, Linux, Mac]
   compilers: [Kotlin 1.3+]


### PR DESCRIPTION
gRPC Java followed Google Play Services and bumped the minimum supported API to 16 (Jelly Bean), see https://github.com/grpc/grpc-java/issues/7244

cc @ejona86 