### PR TITLE
Return to helloworld directory

### DIFF
--- a/content/docs/languages/go/quickstart.md
+++ b/content/docs/languages/go/quickstart.md
@@ -129,7 +129,7 @@ Before you can use the new service method, you need to recompile the updated
 While still in the `examples/helloworld` directory, run the following commands:
 
 ```sh
-$ ( cd ../../cmd/protoc-gen-go-grpc && go install . )
+$ ( cd ../../cmd/protoc-gen-go-grpc && go install . ) && cd -
 $ protoc \
   --go_out=Mgrpc/service_config/service_config.proto=/internal/proto/grpc_service_config:. \
   --go-grpc_out=Mgrpc/service_config/service_config.proto=/internal/proto/grpc_service_config:. \


### PR DESCRIPTION
Running the `protoc..` will throw `No such file or directory` since working directory is moved outside `helloworld`. Proposing to return back to `helloworld` directory after `go install .`