### PR TITLE
Bump params.grpc_release_tag to v1.31.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ pygmentsCodeFences: true
 params:
   repo: https://github.com/grpc/grpc.io
   locale: en_US
-  grpc_release_tag: v1.30.0
+  grpc_release_tag: v1.31.0
   grpc_java_release_tag: v1.30.1
   grpc_go_release_tag: v1.31.0
   font_awesome_version: 5.12.1


### PR DESCRIPTION
Do not merge yet, I'll merge myself once the the release for grpc/grpc is out.