### PR TITLE
Bump grpc-java to 1.31.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ params:
   repo: https://github.com/grpc/grpc.io
   locale: en_US
   grpc_release_tag: v1.30.0
-  grpc_java_release_tag: v1.30.1
+  grpc_java_release_tag: v1.31.1
   grpc_go_release_tag: v1.31.0
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework


### PR DESCRIPTION
This replaces #374, as it uses `mavenCentral()` with the Android projects so we are no longer concerned whether JCenter is out-of-date.