### PR TITLE
Update PHP API Reference landing URL

### DIFF
--- a/content/docs/languages/php/_index.md
+++ b/content/docs/languages/php/_index.md
@@ -1,6 +1,6 @@
 ---
 title: PHP
-api_path: grpc/LANG/namespace-Grpc
+api_path: grpc/LANG/namespace_grpc
 ---
 
 These language-specific pages are available:


### PR DESCRIPTION
This is for the "API Reference" link in this page: https://grpc.io/docs/languages/php/ for PHP.

Follow-up on PR https://github.com/grpc/grpc/pull/23849. We need to change the PHP API reference landing URL.

Current URL being directed to from the grpc.io website: https://grpc.github.io/grpc/php/namespace-Grpc

New URL needs to be: https://grpc.github.io/grpc/php/namespace_grpc. This is already active after https://github.com/grpc/grpc/pull/23849 is merged.