### PR TITLE
Replace deprecated ANDROID_HOME with ANDROID_SDK_ROOT

### DIFF
--- a/content/docs/languages/android/quickstart.md
+++ b/content/docs/languages/android/quickstart.md
@@ -18,7 +18,7 @@ weight: 10
       the following environment variable:
 
       ```sh
-      $ export ANDROID_HOME="<path-to-your-android-sdk>"
+      $ export ANDROID_SDK_ROOT="<path-to-your-android-sdk>"
       ```
 
 - An android device set up for [USB debugging][] or an


### PR DESCRIPTION
Closes #381 

I've walked through the quick start instructions and they continue to work with `ANDROID_SDK_ROOT`.