### PR TITLE
Banner update: link directly to gRPC Conf playlist

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -2,16 +2,12 @@
 <div class="hero-head">
   <div class="notification is-warning has-text-centered">
     <p>
-      Missed
+      For
       <a href="https://events.linuxfoundation.org/grpc-conf/" target="_blank" rel="noopener">
-        <strong>gRPC Conf 2020</strong></a>?
-      Don't worry.
-    </p>
-    <p>
-      Watch session videos from the
-      <a href="https://www.youtube.com/c/cloudnativefdn/" target="_blank" rel="noopener">
+        <strong>gRPC Conf 2020</strong></a>
+      session videos, visit the
+      <a href="https://www.youtube.com/playlist?list=PLj6h78yzYM2NN72UX_fdmc5CZI-D5qfJL" target="_blank" rel="noopener">
         CNCF YouTube channel</a>
-      starting August 5!
     </p>
   </div>
 </div>


### PR DESCRIPTION
Simplify the banner and link directly to the gRPC Conf 2020 playlist.

cc @caniszczyk

Screenshot:
> <img width="429" alt="Screen Shot 2020-09-16 at 13 47 55" src="https://user-images.githubusercontent.com/4140793/93373466-60374480-f823-11ea-8412-6a0f4e423555.png">
