### PR TITLE
Fix PATH order in C++ quickstart guide

### DIFF
--- a/content/docs/languages/cpp/quickstart.md
+++ b/content/docs/languages/cpp/quickstart.md
@@ -29,7 +29,7 @@ $ mkdir -p $MY_INSTALL_DIR
 Add the local `bin` folder to your path variable, for example:
 
 ```sh
-$ export PATH="$PATH:$MY_INSTALL_DIR/bin"
+$ export PATH="$MY_INSTALL_DIR/bin:$PATH"
 ```
 
 ### Prerequisites


### PR DESCRIPTION
Current Quickstart guide assumes complicated dependencies setup. Under this setup OS-installed packages may have gRPC binaries that conflict with the ones built with the guide's instructions. To ensure that the guide's binaries take precedence over OS-wide, PATH environment variable should be set accordingly. In general PATH variable elements have left order precedence. 

The build issue with grpc_cpp_plugin was experienced and solved by changing the PATH order on Archlinux (package probuf  3.12.4-1, protobuf-c 1.3.3-2).