### PR TITLE
Fix redirect rule affecting C# tutorial path

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -23,7 +23,8 @@
 {{ end -}}
 
 # Handle /docs/tutorials/basic/c(.html)?
-/docs/tutorials/basic/c*  /docs/languages/cpp/basics
+/docs/tutorials/basic/c  /docs/languages/cpp/basics
+/docs/tutorials/basic/c.html  /docs/languages/cpp/basics
 
 # C# .NET
 /docs/languages/csharp/dotnet/api  https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Core


### PR DESCRIPTION
Closes  #429

The problematic line was introduced by #341 to address the 404 for `/docs/tutorials/basic/c/` (#340).

Test redirects:
- [ ] https://deploy-preview-430--grpc-io.netlify.app/docs/tutorials/basic/csharp.html
- [ ] https://deploy-preview-430--grpc-io.netlify.app/docs/tutorials/basic/c/
- [ ] https://deploy-preview-430--grpc-io.netlify.app/docs/tutorials/basic/c.html