### PR TITLE
Platforms data table: update min Go version to 1.13+

### DIFF
--- a/data/platforms.yaml
+++ b/data/platforms.yaml
@@ -15,7 +15,7 @@
   compilers: [Dart 2.2+]
 - language: Go
   platforms: [Windows, Linux, Mac]
-  compilers: [Go 1.12+]
+  compilers: [Go 1.13+]
 - language: Java
   platforms: [Windows, Linux, Mac]
   compilers: [JDK 8 recommended (Jelly Bean+ for Android)]


### PR DESCRIPTION
(Maybe the min Go version text should read the same as what is given in the Go Quick start page?)