### PR TITLE
Style: stop yelling nav menu titles

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
 
       <div class="column">
         {{ range site.Menus.main }}
-        {{ $name       := .Name | upper }}
+        {{ $name       := .Name }}
         {{ $isExternal := hasPrefix .URL "http" }}
         <a class="is-size-5 is-size-6-mobile has-text-light" href="{{ .URL }}"{{ if $isExternal }} target="_blank"{{ end }}>
           <span>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -15,7 +15,7 @@
   {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink -}}
   <div class="nav-section" x-data="{ open: {{ $isThisSection }} }">
     {{ $isActive := (or $isThisSection (eq $here .RelPermalink)) -}}
-    {{ $title := .Params.short | default .Title | upper -}}
+    {{ $title := .Params.short | default .Title -}}
     <nav class="level">
       <div class="level-left">
         <a class="nav-section-title is-size-5 is-size-6-mobile{{ if $isActive }} is-active{{ end }}" href="{{ .RelPermalink }}">

--- a/layouts/partials/navbar-menu.html
+++ b/layouts/partials/navbar-menu.html
@@ -1,7 +1,7 @@
 {{ $menu  := site.Menus.main }}
 
 {{ range $menu }}
-{{ $name := .Name | upper }}
+{{ $name := .Name }}
 {{ if .HasChildren }}
 {{ $url := .URL | relLangURL }}
 <div class="navbar-item is-size-5 is-size-6-mobile has-dropdown is-hoverable">
@@ -33,7 +33,7 @@
   </div>
 </div>
 {{ else }}
-{{ $name       := .Name | upper }}
+{{ $name       := .Name }}
 {{ $url        := .URL }}
 {{ $isExternal := hasPrefix .URL "http" }}
 <a class="navbar-item is-size-5 is-size-6-mobile"{{ with $url }} href="{{ . }}"{{ end }}{{ if $isExternal }} target="_blank"{{ end }}>


### PR DESCRIPTION
This is a change that was approved a while back when we were working on the site-reorg preview (#216). If ever there is a feeling that we should keep all UPPERCASE menu title names, then it should be achieved using styling rather than "hard coded" using a Hugo function at site generation time.