### PR TITLE
Fix doc content overflow

### DIFF
--- a/layouts/partials/docs/article.html
+++ b/layouts/partials/docs/article.html
@@ -6,8 +6,8 @@
       <div class="column is-one-quarter is-hidden-touch">
         {{ partial "nav.html" . }}
       </div>
-
-      <div class="column">
+      {{/* Why is-clipped? See https://github.com/grpc/grpc.io/issues/185 */}}
+      <div class="column is-clipped">
         <section class="hero is-small">
           <div class="hero-body">
             <div class="container">


### PR DESCRIPTION
Closes #185. Solution from https://github.com/jgthms/bulma/issues/2616 and https://github.com/jgthms/bulma/issues/1540.

### Screenshots

Before:

> <img src="https://user-images.githubusercontent.com/4140793/96296500-5b4de800-0fbd-11eb-84f2-41da33c37e98.png" width=500>

After:

> <img src="https://user-images.githubusercontent.com/4140793/96296644-97814880-0fbd-11eb-82dd-c9c9507bd37b.png" width=500>

cc @ejona86 