### PR TITLE
Go quick start: use protoc-gen-go from new package

### DIFF
--- a/content/docs/languages/go/quickstart.md
+++ b/content/docs/languages/go/quickstart.md
@@ -22,7 +22,7 @@ spelling: cSpell:ignore Fatalf GOPATH
 
       ```sh
       $ export GO111MODULE=on  # Enable module mode
-      $ go get github.com/golang/protobuf/protoc-gen-go \
+      $ go get google.golang.org/protobuf/cmd/protoc-gen-go \
                google.golang.org/grpc/cmd/protoc-gen-go-grpc
       ```
 


### PR DESCRIPTION
Contributes to #437. I've done the first part of the Quick start to confirm that it works.

Context: https://github.com/grpc/grpc-go/pull/3932#issuecomment-713739663

cc @menghanl