### PR TITLE
Add language-home layout

### DIFF
--- a/content/docs/languages/dart/_index.md
+++ b/content/docs/languages/dart/_index.md
@@ -1,10 +1,13 @@
 ---
 title: Dart
+layout: prog_lang_home
 api_path: https://pub.dev/documentation/grpc
+content:
+  - learn_more:
+    - "[Examples]($src_repo_url/tree/master/example/)"
+  - reference:
+    - "[API](api/)"
+  - other:
+    - $src_repo_link
+    - "[pub package](https://pub.dev/packages/grpc)"
 ---
-
-These language-specific pages are available:
-
-- [Quick start](quickstart/)
-- [Basics tutorial](basics/)
-- [API reference](api)

--- a/layouts/docs/prog_lang_home.html
+++ b/layouts/docs/prog_lang_home.html
@@ -1,0 +1,21 @@
+{{ define "main" -}}
+<section class="section">
+  <div class="container">
+    <div class="columns is-variable is-8">
+      <div class="column is-one-quarter is-hidden-touch">
+        {{ partial "nav.html" . }}
+      </div>
+      {{/* Why is-clipped? See https://github.com/grpc/grpc.io/issues/185 */}}
+      <div class="column is-clipped">
+        {{ partial "docs/hero.html" . }}
+        <section class="section">
+          <div class="container">
+            {{ $content := partial "docs/prog_lang_home" . -}}
+            {{ partial "content.html" (dict "Page" . "content" $content) }}
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</section>
+{{- end -}}

--- a/layouts/partials/docs/prog_lang_home.html
+++ b/layouts/partials/docs/prog_lang_home.html
@@ -1,0 +1,72 @@
+{{ $lang := lower (.Params.language | default .Params.title) -}}
+{{ $Lang := .Params.title | default .Params.language -}}
+{{ $src_repo_url := .Params.src_repo | default (printf "https://github.com/grpc/grpc-%s" $lang) -}}
+{{ $src_repo_link := printf "[grpc-%s repo](%s)" $lang $src_repo_url -}}
+
+{{/* Temporary if-block */}}
+{{- if not (findRE "^http" $src_repo_url) -}}
+  {{- $src_repo_url = printf "https://%s" $src_repo_url -}}
+{{ end -}}
+
+{{ $src_repo_content_url := .Params.src_repo_content | default (printf "https://github.com/grpc/grpc-%s/blob/master" $lang) -}}
+
+{{/* Temporary if-block */}}
+{{- if not (findRE "^http" $src_repo_content_url) -}}
+  {{- $src_repo_content_url = printf "https://%s" $src_repo_content_url -}}
+{{ end -}}
+
+<div class="columns c-deck-of-cards">
+  <div class="column">
+    <div class="card" href="#">
+      <div class="card-content">
+        <h4>
+          <a class="" href="quickstart/">Quick start</a>
+        </h4>
+        <p>
+          Run your first {{ $Lang }} gRPC app in minutes!
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="column">
+    <div class="card">
+      <div class="card-content">
+        <h4>
+          <a class="" href="basics/">Basics tutorial</a>
+        </h4>
+        <p>
+          Learn about {{ $Lang }} gRPC basics.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr>
+
+{{ with .Params.content -}}
+<div class="columns resource-list">
+  {{ range $list_entry := . }}
+  {{ range $heading, $items := $list_entry }}
+  {{ $hd := printf "#### %s" (humanize $heading) -}}
+  <div class="column">
+    {{ $hd | $.Page.RenderString }}
+    <ul>
+      {{ range $items }}
+      {{ $item := replace . "$src_repo_url" $src_repo_url -}}
+      {{ $item = replace $item "$src_repo_link" $src_repo_link -}}
+      <li>{{ $item | $.Page.RenderString }}</li>
+      {{ end }}
+    </ul>
+  </div>
+  {{ end }}
+  {{ end }}
+</div>
+{{ end -}}
+
+{{ with .Content -}}
+<hr>
+
+{{ . }}
+{{ end -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -73,7 +73,7 @@
                 </a>
               </li>
             {{ end -}}
-            {{ if .Params.language }}
+            {{ if hasPrefix .Parent.Dir "docs/languages/" }}
             <li class="nav-section-link">
               <a href="{{ .RelPermalink }}">
                 More ...


### PR DESCRIPTION
This is a key PR for #481. The new layout has been applied to the Dart page as an example. Other pages will be converted shortly.

Preview: https://deploy-preview-482--grpc-io.netlify.app/docs/languages/dart/

### Screenshot

Before:

> <img src="https://user-images.githubusercontent.com/4140793/97491379-7531e800-1938-11eb-96de-7f519e51de65.png" width=300>

After:

> <img src="https://user-images.githubusercontent.com/4140793/97491432-8975e500-1938-11eb-8c98-e85d0d65d5f4.png" width=500>
