### PR TITLE
Android pages: adjust titles and fix left-nav

### DIFF
--- a/content/docs/platforms/android/_index.md
+++ b/content/docs/platforms/android/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Android
+nav_children: section
 ---
 
 The following languages support client-side gRPC on Android:

--- a/content/docs/platforms/android/java/_index.md
+++ b/content/docs/platforms/android/java/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Android Java
+short: Java
 api_path: grpc-java/javadoc
 ---
 

--- a/content/docs/platforms/android/kotlin/_index.md
+++ b/content/docs/platforms/android/kotlin/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Kotlin for Android
+short: Kotlin
 api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
 ---
 

--- a/content/docs/platforms/android/kotlin/quickstart.md
+++ b/content/docs/platforms/android/kotlin/quickstart.md
@@ -1,5 +1,6 @@
 ---
-title: Quick start - Kotlin Android
+title: Quick start - Kotlin for Android
+short: Quick start
 description: This guide gets you started with Kotlin gRPC on Android with a simple working example.
 weight: 10
 ---

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -36,6 +36,11 @@
     <ul class="nav-section-links" x-show="open">
       {{ range . -}}
       {{ $children := .RegularPages -}}
+      {{ if hasPrefix .Params.nav_children "section" -}}
+        {{ $children = .Sections -}}
+      {{ else if hasPrefix .Params.nav_children "pages" -}}
+        {{ $children = .Pages -}}
+      {{ end -}}
       {{ $isThisSection := hasPrefix $currentSection.RelPermalink .CurrentSection.RelPermalink -}}
       {{ $isActive := eq $here .RelPermalink -}}
       {{ if $children -}}
@@ -59,7 +64,7 @@
         {{ if $children -}}
           <ul class="nav-section-links" x-show="open">
             {{ range $children -}}
-              {{ $isActive := eq $here .RelPermalink -}}
+              {{ $isActive := hasPrefix $here .RelPermalink -}}
               {{ $isRedirected :=  findRE "^/docs/(languages|platforms)/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
               {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
               <li class="nav-section-link{{ if $isActive }} is-active{{ end }}">


### PR DESCRIPTION
Followup to #489, #473, contributing to #472.

#### Screenshots

Before:

> ![image](https://user-images.githubusercontent.com/4140793/98004532-0e8c4e80-1dbe-11eb-9a58-428193ccddf1.png)

After:

> ![image](https://user-images.githubusercontent.com/4140793/98004418-e7ce1800-1dbd-11eb-8bdb-06ea3af3ee8b.png)
