### PR TITLE
Cross-link Kotlin/JVM and Kotlin-for-Android pages

### DIFF
--- a/content/docs/languages/kotlin/_index.md
+++ b/content/docs/languages/kotlin/_index.md
@@ -5,12 +5,11 @@ language: Kotlin
 api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
 content:
   - learn_more:
-    - >
-      [Examples]($src_repo_url/tree/master/examples),
-      including for Android
+    - "[Examples]($src_repo_url/tree/master/examples)"
   - reference:
     - "[API](api/)"
   - other:
+    - "[Kotlin for Android](/docs/platforms/android/kotlin)"
     - $src_repo_link
     - "[Download](https://search.maven.org/search?q=g:io.grpc%20AND%20grpc-kotlin)"
 spelling: cSpell:ignore Ferrer youtube

--- a/content/docs/platforms/android/kotlin/_index.md
+++ b/content/docs/platforms/android/kotlin/_index.md
@@ -1,10 +1,16 @@
 ---
 title: Kotlin for Android
-short: Kotlin
+language: &lang Kotlin
+short: *lang
+layout: prog_lang_home
 api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
+content:
+  - learn_more:
+    - "[Example]($src_repo_url/tree/master/examples/android)"
+  - reference:
+    - "[API](api/)"
+  - other:
+    - "[Kotlin/JVM](/docs/languages/kotlin/)"
+    - $src_repo_link
+    - "[Download](https://search.maven.org/search?q=g:io.grpc%20AND%20grpc-kotlin)"
 ---
-
-These language-specific pages are available:
-
-- [Quick start](quickstart/)
-- [API reference](api/)

--- a/layouts/partials/docs/prog_lang_home.html
+++ b/layouts/partials/docs/prog_lang_home.html
@@ -23,12 +23,13 @@
           <a class="" href="quickstart/">Quick start</a>
         </h4>
         <p>
-          Run your first {{ $Lang }} gRPC app in minutes!
+          Run your first {{ replace $Lang " " "-" }} gRPC app in minutes!
         </p>
       </div>
     </div>
   </div>
 
+  {{ if .GetPage "basics" -}}
   <div class="column">
     <div class="card">
       <div class="card-content">
@@ -36,11 +37,12 @@
           <a class="" href="basics/">Basics tutorial</a>
         </h4>
         <p>
-          Learn about {{ $Lang }} gRPC basics.
+          Learn about {{ replace $Lang " " "-" }} gRPC basics.
         </p>
       </div>
     </div>
   </div>
+  {{ end -}}
 </div>
 
 <hr>


### PR DESCRIPTION
Cross-link the Kotlin/JVM and Kotlin-for-Android pages under the **Other** heading of the page. Does this work for you @jamesward @bshaffer @davidwiner, or would you like the cross-page links to be more visible?

#### Preview

- https://deploy-preview-496--grpc-io.netlify.app/docs/languages/kotlin/
- https://deploy-preview-496--grpc-io.netlify.app/docs/platforms/android/kotlin/

#### Screenshots

> <img width="500" alt="Screen Shot 2020-11-03 at 14 53 55" src="https://user-images.githubusercontent.com/4140793/98034150-88cfc980-1de4-11eb-8b06-2a239446eecd.png">

---

> <img width="500" alt="Screen Shot 2020-11-03 at 14 53 17" src="https://user-images.githubusercontent.com/4140793/98034191-95ecb880-1de4-11eb-977d-77e3df2b08c2.png">
