### PR TITLE
Config of gRPC pkg versions: make it easier/more uniform to introduce new languages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,10 @@ params:
   repo: https://github.com/grpc/grpc.io
   branch: main
   locale: en_US
-  grpc_release_tag: v1.33.1
-  grpc_java_release_tag: v1.33.1
-  grpc_go_release_tag: v1.31.0
+  grpc_vers:
+    core: v1.33.1
+    go: v1.31.0
+    java: v1.33.1
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework
 

--- a/content/blog/installation.md
+++ b/content/blog/installation.md
@@ -33,7 +33,7 @@ Go | Linux, Mac, Windows | `go get google.golang.org/grpc`
 Objective-C | Mac | Runtime source fetched automatically from GitHub by CocoaPods
 C# | Windows | Install [gRPC NuGet package](https://www.nuget.org/packages/Grpc/) from your IDE (Visual Studio, Monodevelop, Xamarin Studio)
 Java | Linux, Mac, Windows | Use our [Maven and Gradle plugins](https://github.com/grpc/grpc-java/blob/master/README.md) that provide gRPC with [statically linked `boringssl`](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#openssl-statically-linked-netty-tcnative-boringssl-static)
-C++ | Linux, Mac, Windows | Currently requires [manual build and install](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/src/cpp/README.md)
+C++ | Linux, Mac, Windows | Currently requires [manual build and install](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/src/cpp/README.md)
 
 You can find out more about installation in our [quick start pages](/docs/languages/) and GitHub repositories. Do send us your feedback on our [mailing list](https://groups.google.com/forum/#!forum/grpc-io) or file issues on our issue tracker if you run into any problems.
 

--- a/content/docs/languages/cpp/async.md
+++ b/content/docs/languages/cpp/async.md
@@ -9,10 +9,10 @@ This tutorial shows you how to write a simple server and client in C++ using
 gRPC's asynchronous/non-blocking APIs. It assumes you are already familiar with
 writing simple synchronous gRPC code, as described in [Basics
 tutorial](/docs/languages/android/basics/). The example used in this tutorial follows
-from the basic [Greeter example](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/cpp/helloworld) used in the
+from the basic [Greeter example](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/cpp/helloworld) used in the
 [quick start](../quickstart/). You'll find it along with installation
 instructions in
-[grpc/examples/cpp/helloworld](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/cpp/helloworld).
+[grpc/examples/cpp/helloworld](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/cpp/helloworld).
 
 ### Overview
 
@@ -30,7 +30,7 @@ is as follows:
 
 To use an asynchronous client to call a remote method, you first create a
 channel and stub, just as you do in a [synchronous
-client](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/helloworld/greeter_client.cc). Once you have your stub, you do
+client](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/helloworld/greeter_client.cc). Once you have your stub, you do
 the following to make an asynchronous call:
 
 - Initiate the RPC and create a handle for it. Bind the RPC to a
@@ -62,7 +62,7 @@ the following to make an asynchronous call:
     ```
 
 You can see the complete client example in
-[greeter_async_client.cc](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/helloworld/greeter_async_client.cc).
+[greeter_async_client.cc](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/helloworld/greeter_async_client.cc).
 
 ### Async server
 
@@ -213,4 +213,4 @@ What this means in our example is that `ServerImpl's` destructor looks like:
 ```
 
 You can see our complete server example in
-[greeter_async_server.cc](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/helloworld/greeter_async_server.cc).
+[greeter_async_server.cc](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/helloworld/greeter_async_server.cc).

--- a/content/docs/languages/cpp/basics.md
+++ b/content/docs/languages/cpp/basics.md
@@ -29,12 +29,12 @@ guide](https://developers.google.com/protocol-buffers/docs/reference/cpp-generat
 ### Example code and setup
 
 The example code for our tutorial is in
-[grpc/grpc/examples/cpp/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/cpp/route_guide). To
+[grpc/grpc/examples/cpp/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/cpp/route_guide). To
 download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 ```
 
 Then change your current directory to `examples/cpp/route_guide`:
@@ -54,7 +54,7 @@ Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grp
 define the gRPC *service* and the method *request* and *response* types using
 [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
 You can see the complete .proto file in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -138,10 +138,10 @@ Next we need to generate the gRPC client and server interfaces from our .proto
 service definition. We do this using the protocol buffer compiler `protoc` with
 a special gRPC C++ plugin.
 
-For simplicity, we've provided a [Makefile](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/route_guide/Makefile)
+For simplicity, we've provided a [Makefile](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/route_guide/Makefile)
 that runs `protoc` for you with the appropriate plugin, input, and output (if
 you want to run this yourself, make sure you've installed protoc and followed
-the gRPC code [installation instructions](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/src/cpp/README.md#make) first):
+the gRPC code [installation instructions](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/src/cpp/README.md#make) first):
 
 ```sh
 $ make route_guide.grpc.pb.cc route_guide.pb.cc
@@ -190,7 +190,7 @@ There are two parts to making our `RouteGuide` service do its job:
   service responses.
 
 You can find our example `RouteGuide` server in
-[examples/cpp/route_guide/route_guide_server.cc](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/route_guide/route_guide_server.cc).
+[examples/cpp/route_guide/route_guide_server.cc](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/route_guide/route_guide_server.cc).
 Let's take a closer look at how it works.
 
 #### Implementing RouteGuide
@@ -344,7 +344,7 @@ As you can see, we build and start our server using a `ServerBuilder`. To do thi
 
 In this section, we'll look at creating a C++ client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/cpp/route_guide/route_guide_client.cc](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/cpp/route_guide/route_guide_client.cc).
+[examples/cpp/route_guide/route_guide_client.cc](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/cpp/route_guide/route_guide_client.cc).
 
 #### Creating a stub
 

--- a/content/docs/languages/cpp/quickstart.md
+++ b/content/docs/languages/cpp/quickstart.md
@@ -93,7 +93,7 @@ The following instructions will locally install gRPC and Protocol Buffers.
  2. Clone the `grpc` repo and its submodules:
 
     ```sh
-    $ git clone --recurse-submodules -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+    $ git clone --recurse-submodules -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
     $ cd grpc
     ```
 
@@ -357,10 +357,10 @@ from the example **build** directory `examples/cpp/helloworld/cmake/build`:
 - Work through the [Basics tutorial](../basics/).
 - Explore the [API reference](../api).
 
-[examples/protos/helloworld.proto]: https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/helloworld.proto
+[examples/protos/helloworld.proto]: https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/helloworld.proto
 [github.com/google/protobuf/releases]: https://github.com/google/protobuf/releases
 [Installing CMake]: https://cmake.org/install
 [pb]: https://developers.google.com/protocol-buffers
 [proto3]: https://developers.google.com/protocol-buffers/docs/proto3
-[repo]: https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}
+[repo]: https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}
 [using-grpc]: https://github.com/grpc/grpc/tree/master/src/cpp#to-start-using-grpc-c

--- a/content/docs/languages/csharp/basics.md
+++ b/content/docs/languages/csharp/basics.md
@@ -26,12 +26,12 @@ language: you can find out more in the
 ### Example code and setup
 
 The example code for our tutorial is in
-[grpc/grpc/examples/csharp/RouteGuide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/csharp/RouteGuide). To
+[grpc/grpc/examples/csharp/RouteGuide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/csharp/RouteGuide). To
 download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 ```
 
@@ -39,7 +39,7 @@ All the files for this tutorial are in the directory
 `examples/csharp/RouteGuide`. Open the solution
 `examples/csharp/RouteGuide/RouteGuide.sln` from Visual Studio (Windows or Mac) or Visual Studio Code.
 For additional installation details, see the [How to use
-instructions](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/src/csharp#how-to-use).
+instructions](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/src/csharp#how-to-use).
 
 ### Defining the service
 
@@ -47,7 +47,7 @@ Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grp
 define the gRPC *service* and the method *request* and *response* types using
 [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
 You can see the complete .proto file in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -168,7 +168,7 @@ There are two parts to making our `RouteGuide` service do its job:
   service responses.
 
 You can find our example `RouteGuide` server in
-[examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs).
+[examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs).
 Let's take a closer look at how it works.
 
 #### Implementing RouteGuide
@@ -336,7 +336,7 @@ do this, we:
 
 In this section, we'll look at creating a C# client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/csharp/RouteGuide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/csharp/RouteGuide/RouteGuideClient/Program.cs).
+[examples/csharp/RouteGuide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/csharp/RouteGuide/RouteGuideClient/Program.cs).
 
 #### Creating a client object
 

--- a/content/docs/languages/csharp/quickstart.md
+++ b/content/docs/languages/csharp/quickstart.md
@@ -18,7 +18,7 @@ example by using either an IDE and its build tools,
 or by using the the .NET Core SDK command line tools.
 
 First, make sure you have installed the
-[gRPC C# prerequisites](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/src/csharp/README.md#prerequisites).
+[gRPC C# prerequisites](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/src/csharp/README.md#prerequisites).
 You will also need Git to download the sample code.
 
 ### Download the example
@@ -30,7 +30,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 ```
 
@@ -57,7 +57,7 @@ From the `examples/csharp/Helloworld` directory:
 
 {{< note >}}
 If you want to use gRPC C# from a project that uses the "classic" .csproj files (supported by Visual Studio 2013, 2015 and older versions of Mono), please refer to the
-[Greeter using "classic" .csproj](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/csharp/HelloworldLegacyCsproj/README.md) example.
+[Greeter using "classic" .csproj](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/csharp/HelloworldLegacyCsproj/README.md) example.
 {{< /note >}}
 
 ### Run a gRPC application
@@ -144,7 +144,7 @@ to generate the code. Starting from version 1.17 the package also integrates wit
 MSBuild to provide [automatic C# code generation](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md)
 from `.proto` files.
 
-This example project already depends on the `Grpc.Tools.{{< psubstr grpc_release_tag 1 >}}` NuGet package so just re-building the solution
+This example project already depends on the `Grpc.Tools.{{< psubstr grpc_vers.core 1 >}}` NuGet package so just re-building the solution
 is enough to regenerate the code from our modified `.proto` file.
 
 You can rebuild just like we first built the original

--- a/content/docs/languages/java/basics.md
+++ b/content/docs/languages/java/basics.md
@@ -35,7 +35,7 @@ To download the example, clone the latest release in `grpc-java` repository by
 running the following command:
 
 ```sh
-$ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java.git
+$ git clone -b {{< param grpc_vers.java >}} https://github.com/grpc/grpc-java.git
 ```
 
 Then change your current directory to `grpc-java/examples`:

--- a/content/docs/languages/java/quickstart.md
+++ b/content/docs/languages/java/quickstart.md
@@ -16,7 +16,7 @@ The example code is part of the [grpc-java][] repo.
     the repo:
 
     ```sh
-    $ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java
+    $ git clone -b {{< param grpc_vers.java >}} https://github.com/grpc/grpc-java
     ```
 
  2. Change to the examples directory:
@@ -207,7 +207,7 @@ from the `examples` directory:
 - Explore the [API reference](../api).
 
 [Basics tutorial]: ../basics/
-[download]: https://github.com/grpc/grpc-java/archive/{{< param grpc_java_release_tag >}}.zip
+[download]: https://github.com/grpc/grpc-java/archive/{{< param grpc_vers.java >}}.zip
 [grpc-java]: https://github.com/grpc/grpc-java
 [JDK]: https://jdk.java.net
 [pb]: https://developers.google.com/protocol-buffers

--- a/content/docs/languages/node/basics.md
+++ b/content/docs/languages/node/basics.md
@@ -28,10 +28,10 @@ buffers language. You can find out more in the
 ### Example code and setup
 
 The example code for our tutorial is in
-[grpc/grpc/examples/node/dynamic_codegen/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/node/dynamic_codegen/route_guide).
+[grpc/grpc/examples/node/dynamic_codegen/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/node/dynamic_codegen/route_guide).
 As you'll see if you look at the repository, there's also a very similar-looking
 example in
-[grpc/grpc/examples/node/static_codegen/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/node/static_codegen/route_guide).
+[grpc/grpc/examples/node/static_codegen/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/node/static_codegen/route_guide).
 We have two versions of our route guide example because there are two ways to
 generate the code needed to work with protocol buffers in Node.js - one approach
 uses `Protobuf.js` to dynamically generate the code at runtime, the other uses
@@ -45,7 +45,7 @@ To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 ```
 
@@ -67,7 +67,7 @@ define the gRPC *service* and the method *request* and *response* types using
 [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 see the complete .proto file in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -190,7 +190,7 @@ There are two parts to making our `RouteGuide` service do its job:
   service responses.
 
 You can find our example `RouteGuide` server in
-[examples/node/dynamic_codegen/route_guide/route_guide_server.js](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/node/dynamic_codegen/route_guide/route_guide_server.js).
+[examples/node/dynamic_codegen/route_guide/route_guide_server.js](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/node/dynamic_codegen/route_guide/route_guide_server.js).
 Let's take a closer look at how it works.
 
 #### Implementing RouteGuide
@@ -354,7 +354,7 @@ As you can see, we build and start our server with the following steps:
 
 In this section, we'll look at creating a Node.js client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/node/dynamic_codegen/route_guide/route_guide_client.js](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/node/dynamic_codegen/route_guide/route_guide_client.js).
+[examples/node/dynamic_codegen/route_guide/route_guide_client.js](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/node/dynamic_codegen/route_guide/route_guide_client.js).
 
 #### Creating a stub
 

--- a/content/docs/languages/node/quickstart.md
+++ b/content/docs/languages/node/quickstart.md
@@ -18,7 +18,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 # Navigate to the dynamic codegen "hello, world" Node example:
 $ cd grpc/examples/node/dynamic_codegen
 # Install the example's dependencies

--- a/content/docs/languages/objective-c/basics.md
+++ b/content/docs/languages/objective-c/basics.md
@@ -29,12 +29,12 @@ guide](https://developers.google.com/protocol-buffers/docs/reference/objective-c
 ### Example code and setup {#setup}
 
 The example code for our tutorial is in
-[grpc/grpc/examples/objective-c/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/objective-c/route_guide).
+[grpc/grpc/examples/objective-c/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/objective-c/route_guide).
 To download the example, clone the `grpc` repository by running the following
 commands:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```
@@ -90,7 +90,7 @@ First let's look at how the service we're using is defined. A gRPC *service* and
 its method *request* and *response* types using [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 see the complete .proto file for our example in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -180,7 +180,7 @@ definition. We do this using the protocol buffer compiler (`protoc`) with a
 special gRPC Objective-C plugin.
 
 For simplicity, we've provided a [Podspec
-file](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/objective-c/route_guide/RouteGuide.podspec)
+file](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/objective-c/route_guide/RouteGuide.podspec)
 that runs `protoc` for you with the appropriate plugin, input, and output, and
 describes how to compile the generated files. You just need to run in this
 directory (`examples/objective-c/route_guide`):
@@ -221,7 +221,7 @@ version, and other metadata.
 
 In this section, we'll look at creating an Objective-C client for our
 `RouteGuide` service. You can see our complete example client code in
-[examples/objective-c/route_guide/ViewControllers.m](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/objective-c/route_guide/ViewControllers.m).
+[examples/objective-c/route_guide/ViewControllers.m](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/objective-c/route_guide/ViewControllers.m).
 
 {{< note >}}
 In your apps, for maintainability and readability reasons, you shouldn't

--- a/content/docs/languages/objective-c/oauth2.md
+++ b/content/docs/languages/objective-c/oauth2.md
@@ -23,11 +23,11 @@ token_.
 
 The example code for our tutorial is in
 [gprc/examples/objective-c/auth_sample](https://github.com/grpc/grpc/tree/
-{{< param grpc_release_tag >}}/examples/objective-c/auth_sample). To
+{{< param grpc_vers.core >}}/examples/objective-c/auth_sample). To
 download the example, clone this repository by running the following commands:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```
@@ -95,7 +95,7 @@ everything went as expected).
 
 The next sections guide you step-by-step through how the gRPC call in
 `MakeRPCViewController` is performed. You can see the complete code in
-[MakeRPCViewController.m](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/objective-c/auth_sample/MakeRPCViewController.m).
+[MakeRPCViewController.m](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/objective-c/auth_sample/MakeRPCViewController.m).
 
 ### Create a call with access token {#rpc-call}
 

--- a/content/docs/languages/objective-c/quickstart.md
+++ b/content/docs/languages/objective-c/quickstart.md
@@ -50,7 +50,7 @@ Quickstart. Copy the source code from GitHub
 [repository](https://github.com/grpc/grpc):
 
 ```sh
-$ git clone --recursive -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc.git
+$ git clone --recursive -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc.git
 ```
 
 ### Install gRPC plugins and libraries

--- a/content/docs/languages/php/basics.md
+++ b/content/docs/languages/php/basics.md
@@ -28,12 +28,12 @@ Use [another language](/docs/languages/) to create a gRPC server.
 ### Example code and setup {#setup}
 
 The example code for our tutorial is in
-[grpc/grpc/examples/php/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/php/route_guide).
+[grpc/grpc/examples/php/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/php/route_guide).
 To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 ```
 
 You need grpc-php-plugin to help you generate proto files. You can build it from source:
@@ -87,7 +87,7 @@ First let's look at how the service we're using is defined. A gRPC *service* and
 its method *request* and *response* types using [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 see the complete .proto file for our example in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -215,7 +215,7 @@ The file contains:
 
 In this section, we'll look at creating a PHP client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/php/route_guide/route_guide_client.php](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/php/route_guide/route_guide_client.php).
+[examples/php/route_guide/route_guide_client.php](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/php/route_guide/route_guide_client.php).
 
 #### Constructing a client object
 

--- a/content/docs/languages/php/quickstart.md
+++ b/content/docs/languages/php/quickstart.md
@@ -93,7 +93,7 @@ You can download the pre-compiled gRPC extension from the PECL
 Clone this repository at given release tag
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 ```
 
 ##### Build and install the gRPC C core library
@@ -242,7 +242,7 @@ in the future.
 You can also just build the gRPC PHP protoc plugin by running:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 $ make grpc_php_plugin
@@ -264,7 +264,7 @@ Use [another language](/docs/languages/) to create a gRPC server.
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 # Build grpc_php_plugin to generate proto files if not build before
 $ cd grpc && git submodule update --init && make grpc_php_plugin
 # Navigate to the "hello, world" PHP example:

--- a/content/docs/languages/python/basics.md
+++ b/content/docs/languages/python/basics.md
@@ -28,12 +28,12 @@ guide](https://developers.google.com/protocol-buffers/docs/reference/python-gene
 ### Example code and setup
 
 The example code for this tutorial is in
-[grpc/grpc/examples/python/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/python/route_guide).
+[grpc/grpc/examples/python/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/python/route_guide).
 To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 ```
 
 Then change your current directory to `examples/python/route_guide` in the repository:
@@ -53,7 +53,7 @@ define the gRPC *service* and the method *request* and *response* types using
 [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 see the complete .proto file in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -180,7 +180,7 @@ Creating and running a `RouteGuide` server breaks down into two work items:
   responses.
 
 You can find the example `RouteGuide` server in
-[examples/python/route_guide/route_guide_server.py](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/python/route_guide/route_guide_server.py).
+[examples/python/route_guide/route_guide_server.py](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/python/route_guide/route_guide_server.py).
 
 #### Implementing RouteGuide
 
@@ -307,7 +307,7 @@ server terminates.
 ### Creating the client {#client}
 
 You can see the complete example client code in
-[examples/python/route_guide/route_guide_client.py](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/python/route_guide/route_guide_client.py).
+[examples/python/route_guide/route_guide_client.py](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/python/route_guide/route_guide_client.py).
 
 #### Creating a stub
 

--- a/content/docs/languages/python/quickstart.md
+++ b/content/docs/languages/python/quickstart.md
@@ -57,7 +57,7 @@ Python's gRPC tools include the protocol buffer compiler `protoc` and the
 special plugin for generating server and client code from `.proto` service
 definitions. For the first part of our quick-start example, we've already
 generated the server and client stubs from
-[helloworld.proto](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/protos/helloworld.proto),
+[helloworld.proto](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/protos/helloworld.proto),
 but you'll need the tools for the rest of our quick start, as well as later
 tutorials and your own projects.
 
@@ -76,7 +76,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 # Navigate to the "hello, world" Python example:
 $ cd grpc/examples/python/helloworld
 ```

--- a/content/docs/languages/ruby/basics.md
+++ b/content/docs/languages/ruby/basics.md
@@ -27,12 +27,12 @@ guide](https://developers.google.com/protocol-buffers/docs/proto3).
 ### Example code and setup
 
 The example code for our tutorial is in
-[grpc/grpc/examples/ruby/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/ruby/route_guide).
+[grpc/grpc/examples/ruby/route_guide](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/ruby/route_guide).
 To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc
 ```
 
@@ -53,7 +53,7 @@ define the gRPC *service* and the method *request* and *response* types using
 [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 see the complete .proto file in
-[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/protos/route_guide.proto).
+[`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -139,7 +139,7 @@ a special gRPC Ruby plugin.
 
 If you want to run this yourself, make sure you've installed protoc and followed
 the gRPC Ruby plugin [installation
-instructions](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/src/ruby/README.md) first):
+instructions](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/src/ruby/README.md) first):
 
 Once that's done, the following command can be used to generate the ruby code.
 
@@ -172,7 +172,7 @@ There are two parts to making our `RouteGuide` service do its job:
   service responses.
 
 You can find our example `RouteGuide` server in
-[examples/ruby/route_guide/route_guide_server.rb](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/ruby/route_guide/route_guide_server.rb).
+[examples/ruby/route_guide/route_guide_server.rb](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/ruby/route_guide/route_guide_server.rb).
 Let's take a closer look at how it works.
 
 #### Implementing RouteGuide
@@ -276,7 +276,7 @@ this, we:
 
 In this section, we'll look at creating a Ruby client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/ruby/route_guide/route_guide_client.rb](https://github.com/grpc/grpc/blob/{{< param grpc_release_tag >}}/examples/ruby/route_guide/route_guide_client.rb).
+[examples/ruby/route_guide/route_guide_client.rb](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/ruby/route_guide/route_guide_client.rb).
 
 #### Creating a stub
 

--- a/content/docs/languages/ruby/quickstart.md
+++ b/content/docs/languages/ruby/quickstart.md
@@ -22,7 +22,7 @@ Ruby's gRPC tools include the protocol buffer compiler `protoc` and the special
 plugin for generating server and client code from the `.proto` service
 definitions. For the first part of our quick-start example, we've already
 generated the server and client stubs from
-[helloworld.proto](https://github.com/grpc/grpc/tree/{{< param grpc_release_tag >}}/examples/protos/helloworld.proto),
+[helloworld.proto](https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}/examples/protos/helloworld.proto),
 but you'll need the tools for the rest of our quick start, as well as later
 tutorials and your own projects.
 
@@ -41,7 +41,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_release_tag >}} https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 # Navigate to the "hello, world" Ruby example:
 $ cd grpc/examples/ruby
 ```

--- a/content/docs/platforms/android/java/basics.md
+++ b/content/docs/platforms/android/java/basics.md
@@ -21,10 +21,10 @@ This guide also does not cover anything on the server side. You can check the [J
 
 ### Example code and setup
 
-The example code for our tutorial is in [grpc-java's examples/android](https://github.com/grpc/grpc-java/tree/{{< param grpc_java_release_tag >}}/examples/android). To download the example, clone the `grpc-java` repository by running the following command:
+The example code for our tutorial is in [grpc-java's examples/android](https://github.com/grpc/grpc-java/tree/{{< param grpc_vers.java >}}/examples/android). To download the example, clone the `grpc-java` repository by running the following command:
 
 ```sh
-$ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java.git
+$ git clone -b {{< param grpc_vers.java >}} https://github.com/grpc/grpc-java.git
 ```
 
 Then change your current directory to `grpc-java/examples/android`:
@@ -39,7 +39,7 @@ interface code - if you don't already, follow the setup instructions in the
 
 ### Defining the service
 
-Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [routeguide/app/src/main/proto/route_guide.proto](https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
+Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [routeguide/app/src/main/proto/route_guide.proto](https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
 
 As we're generating Java code in this example, we've specified a `java_package` file option in our .proto:
 
@@ -150,7 +150,7 @@ The following classes are generated from our service definition:
 
 ### Creating the client
 
-In this section, we'll look at creating a Java client for our `RouteGuide` service. You can see our complete example client code in [routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java](https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java).
+In this section, we'll look at creating a Java client for our `RouteGuide` service. You can see our complete example client code in [routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java](https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java).
 
 #### Creating a stub
 
@@ -354,6 +354,6 @@ As with our client-side streaming example, we both get and return a `StreamObser
 Follow the instructions in the [example directory README][] to build and run the
 client and server.
 
-[build.gradle]: https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/routeguide/app/build.gradle#L26
-[example directory README]: https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/examples/android/README.md
-[grpc-java README]: https://github.com/grpc/grpc-java/blob/{{< param grpc_java_release_tag >}}/README.md
+[build.gradle]: https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/routeguide/app/build.gradle#L26
+[example directory README]: https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/README.md
+[grpc-java README]: https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/README.md

--- a/content/docs/platforms/android/java/quickstart.md
+++ b/content/docs/platforms/android/java/quickstart.md
@@ -38,7 +38,7 @@ The example code is part of the [grpc-java][] repo.
     the repo:
 
     ```sh
-    $ git clone -b {{< param grpc_java_release_tag >}} https://github.com/grpc/grpc-java
+    $ git clone -b {{< param grpc_vers.java >}} https://github.com/grpc/grpc-java
     ```
 
  2. Change to the examples directory:
@@ -257,7 +257,7 @@ In the app, use the following values:
 
 [Android Virtual Device]: https://developer.android.com/studio/run/managing-avds.html
 [Basics tutorial]: ../basics/
-[download]: https://github.com/grpc/grpc-java/archive/{{< param grpc_java_release_tag >}}.zip
+[download]: https://github.com/grpc/grpc-java/archive/{{< param grpc_vers.java >}}.zip
 [grpc-java]: https://github.com/grpc/grpc-java
 [JDK]: https://jdk.java.net
 [pb]: https://developers.google.com/protocol-buffers

--- a/content/faq.md
+++ b/content/faq.md
@@ -61,7 +61,7 @@ The gRPC project does not do LTS releases. Given the rolling release model above
 
 ### What is the latest gRPC Version?
 
-The latest release tag is {{< param grpc_release_tag >}}.
+The latest release tag is {{< param grpc_vers.core >}}.
 
 ### When do gRPC releases happen?
 

--- a/layouts/index.release
+++ b/layouts/index.release
@@ -1,1 +1,1 @@
-{{ $.Site.Params.grpc_release_tag }}
+{{ $.Site.Params.grpc_vers.core }}


### PR DESCRIPTION
As suggested in #498, switching to using a **YAML map** to specify gRPC package versions for different languages.

- Closes #498.
- There are no changes in the generated site content. (New languages will be introduced in subsequent PRs.)

If any one of y'all would like to comment and/or approve, that would be grand:
@ejona86 @dfawley @jtattermusch @srini100 