### PR TITLE
Update grpc-go version to v1.33.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.33.1
-    go: v1.31.0
+    go: v1.33.1
     java: v1.33.1
   font_awesome_version: 5.12.1
   description: A high-performance, open source universal RPC framework


### PR DESCRIPTION
Links: https://github.com/grpc/grpc-go/releases, https://github.com/grpc/grpc-go/releases/tag/v1.33.1.