### PR TITLE
Update http2-smarter-at-scale.md

### DIFF
--- a/content/blog/http2-smarter-at-scale.md
+++ b/content/blog/http2-smarter-at-scale.md
@@ -7,7 +7,7 @@ author:
   position: Google
 ---
 
-Much of the web today runs on HTTP/1.1. The spec for HTTP/1.1 was published in June of 1999, just shy of 20 years ago. A lot has changed since then, which makes it all the more remarkable that HTTP/1.1 has persisted and flourished for so long. But in some areas it’s beginning to show its age; for the most part, in that the designers weren’t building for the scale at which HTTP/1.1 would be used and the astonishing amount of traffic that it would come to handle. A not-so-bad case is that subsequent tests can't pass because of a leaked resource from the previous test. The worst case is that some subsequent tests pass that wouldn't have passed at all if the previously passed test had not leaked a resource.
+Much of the web today runs on HTTP/1.1. The spec for HTTP/1.1 was published in June of 1999, just shy of 20 years ago. A lot has changed since then, which makes it all the more remarkable that HTTP/1.1 has persisted and flourished for so long. But in some areas it’s beginning to show its age; for the most part, in that the designers weren’t building for the scale at which HTTP/1.1 would be used and the astonishing amount of traffic that it would come to handle.
 
 <!--more-->
 


### PR DESCRIPTION
The following lines seem to have spilled over from [j-unit blog](https://github.com/grpc/grpc.io/blob/main/content/blog/graceful-cleanup-junit-tests.md). These don't seem to be relevant for HTTP/2 discussion.