### PR TITLE
Go: add link to "Stubbing gRPC in Go" post

### DIFF
--- a/content/docs/languages/go/_index.md
+++ b/content/docs/languages/go/_index.md
@@ -14,11 +14,13 @@ content:
   - other:
     - $src_repo_link
     - "[Performance benchmark](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584&widget=490377658&container=1286539696)"
-spelling: cSpell:ignore Isberner Malte youtube
+spelling: cSpell:ignore Isberner Klerk Malte youtube
 ---
 
 #### Developer stories and talks {#dev-stories}
 
+- **[Stubbing gRPC in Go](https://jadekler.github.io/2020/10/08/stubbing-grpc.html)**,
+  by [Jean de Klerk](https://github.com/jadekler), Google. October 8, 2020.
 - **Talking to Go gRPC Services Via HTTP/1**
   <a class="icon" href="https://youtu.be/Vbw8h0RCn2E"><i class="fab fa-youtube"></i></a>
   <a class="icon" href="https://static.sched.com/hosted_files/grpcconf20/c9/TalkingToGoGRPCviaHTTP1-gRPCConf2020-MalteIsberner.pdf"><i class="far fa-file"></i></a><br>


### PR DESCRIPTION
- Link added to "Developer stories..." section. I haven't worked my way through the article's example, but it does seem like a good candidate post to add to dev stories.
- Contributes to #433 

Preview: https://deploy-preview-523--grpc-io.netlify.app/docs/languages/go/

cc @jadekler @thisisnotapril 