### PR TITLE
C++ specific ALTS authentication page from template

### DIFF
--- a/content/docs/languages/cpp/_index.md
+++ b/content/docs/languages/cpp/_index.md
@@ -5,6 +5,7 @@ src_repo: https://github.com/grpc/grpc
 content:
   - learn_more:
     - "[Async-API tutorial](async/)"
+    - "[ALTS authentication](alts/)"
     - "[Additional docs]($src_repo_url/tree/master/doc)"
     - "[Examples]($src_repo_url/tree/master/examples/cpp)"
   - reference:

--- a/content/docs/languages/cpp/alts.md
+++ b/content/docs/languages/cpp/alts.md
@@ -1,0 +1,59 @@
+---
+title: ALTS authentication
+short: ALTS
+layout: auth_alts
+description: >
+  An overview of gRPC authentication using Application Layer Transport Security
+  (ALTS).
+spelling: cSpell:ignore Authz creds grpcpp
+code:
+  client_credentials: |
+    ```cpp
+    #include <grpcpp/grpcpp.h>
+    #include <grpcpp/security/credentials.h>
+
+    using grpc::experimental::AltsCredentials;
+    using grpc_impl::experimental::AltsCredentialsOptions;
+
+    auto creds = AltsCredentials(AltsCredentialsOptions());
+    std::shared_ptr<grpc::Channel> channel = CreateChannel(server_address, creds);
+    ```
+  server_credentials: |
+    ```cpp
+    #include <grpcpp/security/server_credentials.h>
+    #include <grpcpp/server.h>
+    #include <grpcpp/server_builder.h>
+
+    using grpc::experimental::AltsServerCredentials;
+    using grpc_impl::experimental::AltsServerCredentialsOptions;
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service);
+    auto creds = AltsServerCredentials(AltsServerCredentialsOptions());
+    builder.AddListeningPort("[::]:<port>", creds);
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    ```
+  server_authorization: |
+    ```cpp
+    #include <grpcpp/grpcpp.h>
+    #include <grpcpp/security/credentials.h>
+
+    using grpc::experimental::AltsCredentials;
+    using grpc_impl::experimental::AltsCredentialsOptions;
+
+    AltsCredentialsOptions opts;
+    opts.target_service_accounts.push_back("expected_server_service_account1");
+    opts.target_service_accounts.push_back("expected_server_service_account2");
+    auto creds = AltsCredentials(opts);
+    std::shared_ptr<grpc::Channel> channel = CreateChannel(server_address, creds);
+    ```
+  client_authorization: |
+    ```cpp
+    #include <grpcpp/server_context.h>
+    #include <grpcpp/security/alts_util.h>
+
+    grpc::ServerContext* context;
+    grpc::Status status = experimental::AltsClientAuthzCheck(
+        context->auth_context(), {"foo@iam.gserviceaccount.com"});
+    ```
+---

--- a/layouts/docs/auth_alts.html
+++ b/layouts/docs/auth_alts.html
@@ -1,0 +1,21 @@
+{{ define "main" -}}
+<section class="section">
+  <div class="container">
+    <div class="columns is-variable is-8">
+      <div class="column is-one-quarter is-hidden-touch">
+        {{ partial "nav.html" . }}
+      </div>
+      {{/* Why is-clipped? See https://github.com/grpc/grpc.io/issues/185 */}}
+      <div class="column is-clipped">
+        {{ partial "docs/hero.html" . }}
+        <section class="section">
+          <div class="container">
+            {{ $content := partial "docs/auth_alts.md" . | $.Page.RenderString -}}
+            {{ partial "content.html" (dict "Page" . "content" $content) }}
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</section>
+{{- end -}}

--- a/layouts/partials/docs/auth_alts.md
+++ b/layouts/partials/docs/auth_alts.md
@@ -1,0 +1,68 @@
+### Overview
+
+Application Layer Transport Security (ALTS) is a mutual authentication and
+transport encryption system developed by Google. It is used for securing RPC
+communications within Google's infrastructure. ALTS is similar to mutual TLS
+but has been designed and optimized to meet the needs of Google's production
+environments. For more information, take a look at the
+[ALTS whitepaper](https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security).
+
+ALTS in gRPC has the following features:
+
+-   Create gRPC servers & clients with ALTS as the transport security protocol.
+-   ALTS connections are end-to-end protected with privacy and integrity.
+-   Applications can access peer information such as the peer service account.
+-   Client authorization and server authorization support.
+-   Minimal code changes to enable ALTS.
+
+gRPC users can configure their applications to use ALTS as a transport security
+protocol with few lines of code. gRPC ALTS is supported in C++, Java, Go, and
+Python.
+
+Note that ALTS is fully functional if the application runs on
+[Google Cloud Platform](https://cloud.google.com/). ALTS could be run on any
+platforms with a pluggable
+[ALTS handshaker service](https://github.com/grpc/grpc/blob/7e367da22a137e2e7caeae8342c239a91434ba50/src/proto/grpc/gcp/handshaker.proto#L224-L234).
+
+### gRPC Client with ALTS Transport Security Protocol
+
+gRPC clients can use ALTS credentials to connect to servers, as illustrated in
+the following code excerpt:
+
+{{ with .Params.code.client_credentials -}}{{ . | markdownify -}}{{ end }}
+
+### gRPC Server with ALTS Transport Security Protocol
+
+gRPC servers can use ALTS credentials to allow clients to connect to them, as
+illustrated next:
+
+{{ with .Params.code.server_credentials -}}{{ . | markdownify -}}{{ end }}
+
+### Server Authorization
+
+gRPC has built-in server authorization support using ALTS. A gRPC client using
+ALTS can set the expected server service accounts prior to establishing a
+connection. Then, at the end of the handshake, server authorization guarantees
+that the server identity matches one of the service accounts specified
+by the client. Otherwise, the connection fails.
+
+{{ with .Params.code.server_authorization -}}{{ . | markdownify -}}{{ end }}
+
+### Client Authorization
+
+On a successful connection, the peer information (e.g., client’s service
+account) is stored in the [AltsContext][]. gRPC provides a utility library for
+client authorization check. Assuming that the server knows the expected client
+identity (e.g., `foo@iam.gserviceaccount.com`), it can run the following example
+codes to authorize the incoming RPC.
+
+[AltsContext]: https://github.com/grpc/grpc/blob/master/src/proto/grpc/gcp/altscontext.proto
+
+
+{{ with .Params.code.client_authorization -}}{{ . | markdownify -}}{{ end }}
+
+{{ with .Content -}}
+<hr>
+
+{{ . }}
+{{ end -}}

--- a/layouts/partials/docs/auth_alts.md
+++ b/layouts/partials/docs/auth_alts.md
@@ -24,20 +24,25 @@ Note that ALTS is fully functional if the application runs on
 platforms with a pluggable
 [ALTS handshaker service](https://github.com/grpc/grpc/blob/7e367da22a137e2e7caeae8342c239a91434ba50/src/proto/grpc/gcp/handshaker.proto#L224-L234).
 
+{{ with .Params.code.client_credentials -}}
 ### gRPC Client with ALTS Transport Security Protocol
 
 gRPC clients can use ALTS credentials to connect to servers, as illustrated in
 the following code excerpt:
 
-{{ with .Params.code.client_credentials -}}{{ . | markdownify -}}{{ end }}
+{{ . | markdownify -}}
+{{ end }}
 
+{{ with .Params.code.server_credentials -}}
 ### gRPC Server with ALTS Transport Security Protocol
 
 gRPC servers can use ALTS credentials to allow clients to connect to them, as
 illustrated next:
 
-{{ with .Params.code.server_credentials -}}{{ . | markdownify -}}{{ end }}
+{{ . | markdownify -}}
+{{ end }}
 
+{{ with .Params.code.server_authorization -}}
 ### Server Authorization
 
 gRPC has built-in server authorization support using ALTS. A gRPC client using
@@ -46,8 +51,10 @@ connection. Then, at the end of the handshake, server authorization guarantees
 that the server identity matches one of the service accounts specified
 by the client. Otherwise, the connection fails.
 
-{{ with .Params.code.server_authorization -}}{{ . | markdownify -}}{{ end }}
+{{ . | markdownify -}}
+{{ end }}
 
+{{ with .Params.code.client_authorization -}}
 ### Client Authorization
 
 On a successful connection, the peer information (e.g., client’s service
@@ -58,11 +65,5 @@ codes to authorize the incoming RPC.
 
 [AltsContext]: https://github.com/grpc/grpc/blob/master/src/proto/grpc/gcp/altscontext.proto
 
-
-{{ with .Params.code.client_authorization -}}{{ . | markdownify -}}{{ end }}
-
-{{ with .Content -}}
-<hr>
-
-{{ . }}
-{{ end -}}
+{{ . | markdownify -}}
+{{ end }}


### PR DESCRIPTION
This is a first example of **using templates to generate pages with language-specific content**. The template contains the common content, and the language-specific page (which refers to the template) only contains the variables parts -- code excerpts, in this specific case.

This PR:

- Introduces a **template** for the **ALTS authentication page**. The template contains the **prose**, in markdown.
- The template is used to create a **C++-specific** ALTS authentication page. The C++ page refers to the template and provides the **code excerpts**.

For context, see #527.

If this PR is ok'd and merged, I'll create followup PRs for the other languages, and drop the catch-all guide.

---

Preview:

- Original "catch-all-languages" version of the page:
  https://deploy-preview-528--grpc-io.netlify.app/docs/guides/auth/alts/
- C++-specific version of the page:
  https://deploy-preview-528--grpc-io.netlify.app/docs/languages/cpp/alts/

---

cc @thisisnotapril 