### PR TITLE
Platform tweaks

### DIFF
--- a/content/docs/platforms/_index.md
+++ b/content/docs/platforms/_index.md
@@ -15,9 +15,7 @@ Select a target platform to get started:
   - [Android]({{< relref "android">}})
   - iOS -- coming soon
 - [Web]({{< relref "web" >}})
-
-Or, explore the following cross-platform software development kit:
-
-- Flutter -- coming soon
+- Flutter
+  - documentation coming soon
 
 [language]: {{< relref "languages" >}}

--- a/content/docs/platforms/_index.md
+++ b/content/docs/platforms/_index.md
@@ -9,13 +9,13 @@ nav_children: section
 Each gRPC [language][] / platform has links to the following pages and more:
 quick start, tutorials, API reference.
 
-Select a target platform to get started:
+Select a development or target platform to get started:
 
+- Flutter
+  - Docs coming soon
 - Mobile:
   - [Android]({{< relref "android">}})
-  - iOS -- coming soon
+  - iOS -- docs coming soon
 - [Web]({{< relref "web" >}})
-- Flutter
-  - documentation coming soon
 
 [language]: {{< relref "languages" >}}


### PR DESCRIPTION
Following up from https://github.com/grpc/grpc.io/pull/525, I think our preference (cc @timsneath) is to do something like this instead

Preview: https://deploy-preview-529--grpc-io.netlify.app/docs/platforms/