### PR TITLE
Go-specific ALTS authentication page from template

### DIFF
--- a/content/docs/guides/auth/ALTS.md
+++ b/content/docs/guides/auth/ALTS.md
@@ -27,7 +27,10 @@ protocol with few lines of code. gRPC ALTS is supported in C++, Java, Go, and
 Python.
 
 Details are covered in this page, or in the following language-specific
-page: [C++ ALTS]({{< relref "docs/languages/cpp/alts" >}}).
+pages:
+
+- [ALTS in C++]({{< relref "docs/languages/cpp/alts" >}})
+- [ALTS in Go]({{< relref "docs/languages/go/alts" >}})
 
 Note that ALTS is fully functional if the application runs on
 [Google Cloud Platform](https://cloud.google.com). ALTS could be run on any
@@ -47,18 +50,6 @@ import io.grpc.ManagedChannel;
 
 ManagedChannel managedChannel =
     AltsChannelBuilder.forTarget(serverAddress).build();
-```
-
-#### Go
-
-```go
-import (
-  "google.golang.org/grpc"
-  "google.golang.org/grpc/credentials/alts"
-)
-
-altsTC := alts.NewClientCreds(alts.DefaultClientOptions())
-conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(altsTC))
 ```
 
 #### Python
@@ -85,18 +76,6 @@ import io.grpc.Server;
 Server server = AltsServerBuilder.forPort(<port>)
     .addService(new MyServiceImpl()).build().start();
 
-```
-
-#### Go
-
-```go
-import (
-  "google.golang.org/grpc"
-  "google.golang.org/grpc/credentials/alts"
-)
-
-altsTC := alts.NewServerCreds(alts.DefaultServerOptions())
-server := grpc.NewServer(grpc.Creds(altsTC))
 ```
 
 #### Python
@@ -130,20 +109,6 @@ ManagedChannel channel =
          .build();
 ```
 
-#### Go
-
-```go
-import (
-  "google.golang.org/grpc"
-  "google.golang.org/grpc/credentials/alts"
-)
-
-clientOpts := alts.DefaultClientOptions()
-clientOpts.TargetServiceAccounts = []string{expectedServerSA}
-altsTC := alts.NewClientCreds(clientOpts)
-conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(altsTC))
-```
-
 ### Client Authorization
 
 On a successful connection, the peer information (e.g., client’s service
@@ -164,15 +129,4 @@ import io.grpc.Status;
 ServerCall<?, ?> call;
 Status status = AuthorizationUtil.clientAuthorizationCheck(
     call, Lists.newArrayList("foo@iam.gserviceaccount.com"));
-```
-
-#### Go
-
-```go
-import (
-  "google.golang.org/grpc"
-  "google.golang.org/grpc/credentials/alts"
-)
-
-err := alts.ClientAuthorizationCheck(ctx, []string{"foo@iam.gserviceaccount.com"})
 ```

--- a/content/docs/languages/cpp/alts.md
+++ b/content/docs/languages/cpp/alts.md
@@ -1,10 +1,11 @@
 ---
-title: ALTS authentication
+title: ALTS authentication in C++
 short: ALTS
 layout: auth_alts
 description: >
   An overview of gRPC authentication in C++ using Application Layer Transport
   Security (ALTS).
+weight: 75
 spelling: cSpell:ignore Authz creds grpcpp
 code:
   client_credentials: |

--- a/content/docs/languages/go/_index.md
+++ b/content/docs/languages/go/_index.md
@@ -4,9 +4,9 @@ layout: prog_lang_home
 api_path: https://pkg.go.dev/google.golang.org/grpc
 content:
   - learn_more:
-    - "[Examples]($src_repo_url/tree/master/examples)"
+    - "[ALTS authentication](alts/)"
     - "[Additional docs]($src_repo_url/tree/master/Documentation)"
-    - "[Installation]($src_repo_url#installation)"
+    - "[Examples]($src_repo_url/tree/master/examples)"
     - "[FAQ]($src_repo_url#faq)"
   - reference:
     - "[API](api/)"
@@ -14,6 +14,7 @@ content:
   - other:
     - $src_repo_link
     - "[Performance benchmark](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584&widget=490377658&container=1286539696)"
+    - "[Installation]($src_repo_url#installation)"
 spelling: cSpell:ignore Isberner Klerk Malte youtube
 ---
 

--- a/content/docs/languages/go/alts.md
+++ b/content/docs/languages/go/alts.md
@@ -1,0 +1,52 @@
+---
+title: ALTS authentication in Go
+short: ALTS
+layout: auth_alts
+description: >
+  An overview of gRPC authentication in Go using Application Layer Transport
+  Security (ALTS).
+weight: 75
+spelling: cSpell:ignore creds
+code:
+  client_credentials: |
+    ```go
+    import (
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials/alts"
+    )
+
+    altsTC := alts.NewClientCreds(alts.DefaultClientOptions())
+    conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(altsTC))
+    ```
+  server_credentials: |
+    ```go
+    import (
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials/alts"
+    )
+
+    altsTC := alts.NewServerCreds(alts.DefaultServerOptions())
+    server := grpc.NewServer(grpc.Creds(altsTC))
+    ```
+  server_authorization: |
+    ```go
+    import (
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials/alts"
+    )
+
+    clientOpts := alts.DefaultClientOptions()
+    clientOpts.TargetServiceAccounts = []string{expectedServerSA}
+    altsTC := alts.NewClientCreds(clientOpts)
+    conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(altsTC))
+    ```
+  client_authorization: |
+    ```go
+    import (
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials/alts"
+    )
+
+    err := alts.ClientAuthorizationCheck(ctx, []string{"foo@iam.gserviceaccount.com"})
+    ```
+---


### PR DESCRIPTION
- Contributes to #527
- Also included are minor tweaks to the C++-ALTS page

FYI @dfawley - note that this PR isn't introducing new content, it's just moving the Go-specific code snippets into a Go-specific ALTS page, which is derived from a shared template that is used for the other supported languages too.

Preview:

- Original "catch-all-languages" version of the page:
  https://deploy-preview-537--grpc-io.netlify.app/docs/guides/auth/alts/
- Go-specific version of the page:
  https://deploy-preview-537--grpc-io.netlify.app/docs/languages/go/alts/
