### PR TITLE
Java-specific ALTS authentication page from template

### DIFF
--- a/content/docs/guides/auth/ALTS.md
+++ b/content/docs/guides/auth/ALTS.md
@@ -31,6 +31,7 @@ pages:
 
 - [ALTS in C++]({{< relref "docs/languages/cpp/alts" >}})
 - [ALTS in Go]({{< relref "docs/languages/go/alts" >}})
+- [ALTS in Java]({{< relref "docs/languages/java/alts" >}})
 
 Note that ALTS is fully functional if the application runs on
 [Google Cloud Platform](https://cloud.google.com). ALTS could be run on any
@@ -41,16 +42,6 @@ platforms with a pluggable
 
 gRPC clients can use ALTS credentials to connect to servers. The following
 provides examples of how to set up such clients in all supported gRPC languages.
-
-#### Java
-
-```java
-import io.grpc.alts.AltsChannelBuilder;
-import io.grpc.ManagedChannel;
-
-ManagedChannel managedChannel =
-    AltsChannelBuilder.forTarget(serverAddress).build();
-```
 
 #### Python
 
@@ -66,17 +57,6 @@ channel = grpc.secure_channel(address, channel_creds)
 gRPC servers can use ALTS credentials to allow clients to connect to them. The
 following provides examples of how to set up such servers in all supported gRPC
 languages.
-
-#### Java
-
-```java
-import io.grpc.alts.AltsServerBuilder;
-import io.grpc.Server;
-
-Server server = AltsServerBuilder.forPort(<port>)
-    .addService(new MyServiceImpl()).build().start();
-
-```
 
 #### Python
 
@@ -96,19 +76,6 @@ connection. Then, at the end of the handshake, server authorization guarantees
 that the server identity matches one of the service accounts specified
 by the client. Otherwise, the connection fails.
 
-#### Java
-
-```java
-import io.grpc.alts.AltsChannelBuilder;
-import io.grpc.ManagedChannel;
-
-ManagedChannel channel =
-     AltsChannelBuilder.forTarget(serverAddress)
-         .addTargetServiceAccount("expected_server_service_account1")
-         .addTargetServiceAccount("expected_server_service_account2")
-         .build();
-```
-
 ### Client Authorization
 
 On a successful connection, the peer information (e.g., client’s service
@@ -118,15 +85,3 @@ gRPC provides a utility library for
 client authorization check. Assuming that the server knows the expected client
 identity (e.g., foo@iam.gserviceaccount.com), it can run the following example
 codes to authorize the incoming RPC.
-
-#### Java
-
-```java
-import io.grpc.alts.AuthorizationUtil;
-import io.grpc.ServerCall;
-import io.grpc.Status;
-
-ServerCall<?, ?> call;
-Status status = AuthorizationUtil.clientAuthorizationCheck(
-    call, Lists.newArrayList("foo@iam.gserviceaccount.com"));
-```

--- a/content/docs/languages/java/_index.md
+++ b/content/docs/languages/java/_index.md
@@ -5,8 +5,9 @@ spelling: cSpell:ignore javadoc Kanti Katirtzis Nikos Sharma Tomo Tuhin youtube 
 api_path: grpc-java/javadoc
 content:
   - learn_more:
-    - "[Examples]($src_repo_url/tree/master/examples)"
+    - "[ALTS authentication](alts/)"
     - "[Additional docs]($src_repo_url/tree/master/documentation)"
+    - "[Examples]($src_repo_url/tree/master/examples)"
   - reference:
     - "[API](api/)"
     - "[Generated code](generated-code/)"

--- a/content/docs/languages/java/alts.md
+++ b/content/docs/languages/java/alts.md
@@ -1,0 +1,47 @@
+---
+title: ALTS authentication in Java
+short: ALTS
+layout: auth_alts
+description: >
+  An overview of gRPC authentication in Java using Application Layer Transport
+  Security (ALTS).
+weight: 75
+code:
+  client_credentials: |
+    ```java
+    import io.grpc.alts.AltsChannelBuilder;
+    import io.grpc.ManagedChannel;
+
+    ManagedChannel managedChannel =
+        AltsChannelBuilder.forTarget(serverAddress).build();
+    ```
+  server_credentials: |
+    ```java
+    import io.grpc.alts.AltsServerBuilder;
+    import io.grpc.Server;
+
+    Server server = AltsServerBuilder.forPort(<port>)
+        .addService(new MyServiceImpl()).build().start();
+    ```
+  server_authorization: |
+    ```java
+    import io.grpc.alts.AltsChannelBuilder;
+    import io.grpc.ManagedChannel;
+
+    ManagedChannel channel =
+        AltsChannelBuilder.forTarget(serverAddress)
+            .addTargetServiceAccount("expected_server_service_account1")
+            .addTargetServiceAccount("expected_server_service_account2")
+            .build();
+    ```
+  client_authorization: |
+    ```java
+    import io.grpc.alts.AuthorizationUtil;
+    import io.grpc.ServerCall;
+    import io.grpc.Status;
+
+    ServerCall<?, ?> call;
+    Status status = AuthorizationUtil.clientAuthorizationCheck(
+        call, Lists.newArrayList("foo@iam.gserviceaccount.com"));
+    ```
+---

--- a/layouts/partials/docs/auth_alts.md
+++ b/layouts/partials/docs/auth_alts.md
@@ -9,11 +9,11 @@ environments. For more information, take a look at the
 
 ALTS in gRPC has the following features:
 
--   Create gRPC servers & clients with ALTS as the transport security protocol.
--   ALTS connections are end-to-end protected with privacy and integrity.
--   Applications can access peer information such as the peer service account.
--   Client authorization and server authorization support.
--   Minimal code changes to enable ALTS.
+- Create gRPC servers & clients with ALTS as the transport security protocol.
+- ALTS connections are end-to-end protected with privacy and integrity.
+- Applications can access peer information such as the peer service account.
+- Client authorization and server authorization support.
+- Minimal code changes to enable ALTS.
 
 gRPC users can configure their applications to use ALTS as a transport security
 protocol with few lines of code.
@@ -29,7 +29,7 @@ platforms with a pluggable
 gRPC clients can use ALTS credentials to connect to servers, as illustrated in
 the following code excerpt:
 
-{{ . | markdownify -}}
+{{ . | safeHTML }}
 {{ end }}
 
 {{ with .Params.code.server_credentials -}}
@@ -38,7 +38,7 @@ the following code excerpt:
 gRPC servers can use ALTS credentials to allow clients to connect to them, as
 illustrated next:
 
-{{ . | markdownify -}}
+{{ . | safeHTML }}
 {{ end }}
 
 {{ with .Params.code.server_authorization -}}
@@ -50,7 +50,7 @@ connection. Then, at the end of the handshake, server authorization guarantees
 that the server identity matches one of the service accounts specified
 by the client. Otherwise, the connection fails.
 
-{{ . | markdownify -}}
+{{ . | safeHTML }}
 {{ end }}
 
 {{ with .Params.code.client_authorization -}}
@@ -64,5 +64,5 @@ codes to authorize the incoming RPC.
 
 [AltsContext]: https://github.com/grpc/grpc/blob/master/src/proto/grpc/gcp/altscontext.proto
 
-{{ . | markdownify -}}
+{{ . | safeHTML }}
 {{ end }}


### PR DESCRIPTION
- Contributes to #527
- Fix code rendering; ensure that blank lines are also rendered

Preview:

- Original "catch-all-languages" version of the page:
  https://deploy-preview-538--grpc-io.netlify.app/docs/guides/auth/alts/
- Go-specific version of the page:
  https://deploy-preview-538--grpc-io.netlify.app/docs/languages/java/alts/
