### PR TITLE
Python-specific ALTS authentication page from template

### DIFF
--- a/content/docs/guides/auth/ALTS.md
+++ b/content/docs/guides/auth/ALTS.md
@@ -32,6 +32,7 @@ pages:
 - [ALTS in C++]({{< relref "docs/languages/cpp/alts" >}})
 - [ALTS in Go]({{< relref "docs/languages/go/alts" >}})
 - [ALTS in Java]({{< relref "docs/languages/java/alts" >}})
+- [ALTS in Python]({{< relref "docs/languages/python/alts" >}})
 
 Note that ALTS is fully functional if the application runs on
 [Google Cloud Platform](https://cloud.google.com). ALTS could be run on any
@@ -43,30 +44,11 @@ platforms with a pluggable
 gRPC clients can use ALTS credentials to connect to servers. The following
 provides examples of how to set up such clients in all supported gRPC languages.
 
-#### Python
-
-```python
-import grpc
-
-channel_creds = grpc.alts_channel_credentials()
-channel = grpc.secure_channel(address, channel_creds)
-```
-
 ### gRPC Server with ALTS Transport Security Protocol
 
 gRPC servers can use ALTS credentials to allow clients to connect to them. The
 following provides examples of how to set up such servers in all supported gRPC
 languages.
-
-#### Python
-
-```python
-import grpc
-
-server = grpc.server(futures.ThreadPoolExecutor())
-server_creds = grpc.alts_server_credentials()
-server.add_secure_port(server_address, server_creds)
-```
 
 ### Server Authorization
 

--- a/content/docs/guides/auth/_index.md
+++ b/content/docs/guides/auth/_index.md
@@ -28,8 +28,12 @@ The following authentication mechanisms are built-in to gRPC:
   [ALTS](https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security)
   as a transport security mechanism, if the application is running on
   [Google Cloud Platform (GCP)](https://cloud.google.com).
-  For details, see [ALTS authentication](alts/) or the following
-  language-specific page: [C++ ALTS]({{< relref "docs/languages/cpp/alts" >}}).
+  For details, see one of the following
+  language-specific pages:
+  [ALTS in C++]({{< relref "docs/languages/cpp/alts" >}}),
+  [ALTS in Go]({{< relref "docs/languages/go/alts" >}}),
+  [ALTS in Java]({{< relref "docs/languages/java/alts" >}}),
+  [ALTS in Python]({{< relref "docs/languages/python/alts" >}}).
 - **Token-based authentication with Google**: gRPC provides a generic
   mechanism (described below) to attach metadata based credentials to requests
   and responses. Additional support for acquiring access tokens

--- a/content/docs/languages/python/_index.md
+++ b/content/docs/languages/python/_index.md
@@ -4,6 +4,7 @@ layout: prog_lang_home
 src_repo: https://github.com/grpc/grpc
 content:
   - learn_more:
+    - "[ALTS authentication](alts/)"
     - "[Additional docs]($src_repo_url/tree/master/doc/python)"
     - "[Examples]($src_repo_url/tree/master/examples/python)"
   - reference:

--- a/content/docs/languages/python/alts.md
+++ b/content/docs/languages/python/alts.md
@@ -1,0 +1,28 @@
+---
+title: ALTS authentication in Python
+short: ALTS
+layout: auth_alts
+description: >
+  An overview of gRPC authentication in Python using Application Layer Transport
+  Security (ALTS).
+weight: 75
+spelling: cSpell:ignore creds
+code:
+  client_credentials: |
+    ```python
+    import grpc
+
+    channel_creds = grpc.alts_channel_credentials()
+    channel = grpc.secure_channel(address, channel_creds)
+    ```
+  server_credentials: |
+    ```python
+    import grpc
+
+    server = grpc.server(futures.ThreadPoolExecutor())
+    server_creds = grpc.alts_server_credentials()
+    server.add_secure_port(server_address, server_creds)
+    ```
+  # server_authorization:
+  # client_authorization:
+---


### PR DESCRIPTION
Contributes to #527

Preview:

- Original "catch-all-languages" version of the page:
  https://deploy-preview-539--grpc-io.netlify.app/docs/guides/auth/alts/
- Go-specific version of the page:
  https://deploy-preview-539--grpc-io.netlify.app/docs/languages/python/alts/
