### PR TITLE
Drop /release

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -64,11 +64,9 @@ outputFormats:
     baseName: _redirects
   RSS:
     baseName: feed
-  RELEASE:
-    baseName: release
 
 outputs:
-  home: [HTML, REDIRECTS, RSS, RELEASE]
+  home: [HTML, REDIRECTS, RSS]
 
 # Site menus
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -109,4 +109,3 @@
 
 /docs/installation/go.html  /docs/languages/go
 /grpc.github.io/img/landing-2.svg  /img/landing-2.svg
-/release)  /release

--- a/layouts/index.release
+++ b/layouts/index.release
@@ -1,1 +1,0 @@
-{{ $.Site.Params.grpc_vers.core }}


### PR DESCRIPTION
Closes #502

Note that I haven't included a redirect rule, since IMHO, it is probably best that any old script that made use of `https://grpc.io/release` should fail with a 404, rather than be redirected and eventually result in a 200 status. If someone really feels strongly about adding a redirect rule, then maybe https://github.com/grpc/grpc/releases might make sense.