### PR TITLE
Objective-C: update macOS and iOS versions to match grpc core config

### DIFF
--- a/data/officially_supported_lang_os.yaml
+++ b/data/officially_supported_lang_os.yaml
@@ -26,7 +26,7 @@
   os: [Windows, Linux, Mac]
   compilers: [Node v4+]
 - language: Objective-C
-  os: [Mac OS X 10.11+, iOS 7.0+]
+  os: [macOS 10.10+, iOS 9.0+]
   compilers: [Xcode 7.2+]
 - language: PHP
   os: [Linux, Mac]


### PR DESCRIPTION
Match verions of https://github.com/grpc/grpc/pull/24282:

> Supported platform changes:
> 
> * iOS 9 or later (from 7)
> * OSX 10.10 or later (from 10.9)

@veblush @yulin-liang