### PR TITLE
install pcel the url should start with https

### DIFF
--- a/content/en/docs/languages/php/quickstart.md
+++ b/content/en/docs/languages/php/quickstart.md
@@ -36,7 +36,7 @@ $ sudo yum install php56w php56w-devel php-pear phpunit gcc zlib-devel
 
 ```sh
 $ brew install php
-$ curl -O http://pear.php.net/go-pear.phar
+$ curl -O https://pear.php.net/go-pear.phar
 $ sudo php -d detect_unicode=0 go-pear.phar
 ```
 


### PR DESCRIPTION
http://pear.php.net/go-pear.phar was redirect to https://pear.php.net/go-pear.phar
It cause 301 redirect error if without http(s)