### PR TITLE
Java basics tutorial typo

### DIFF
--- a/content/docs/languages/java/basics.md
+++ b/content/docs/languages/java/basics.md
@@ -504,7 +504,7 @@ Rectangle request =
 Iterator<Feature> features;
 try {
   features = blockingStub.listFeatures(request);
-} catch (StatusRuntimeException ex) {
+} catch (StatusRuntimeException e) {
   logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
   return;
 }


### PR DESCRIPTION
`ex` to `e` in `catch ( ... )`
or, `e.getStatus()` to `ex.getStatus()`