### PR TITLE
Make page titles unique: reorder title parts

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,6 @@
 {
     "version": "0.1",
     "language": "en",
-    // Workspace dictionary:
     "words": [
         "backends",
         "Bazel",
@@ -11,7 +10,10 @@
         "deallocate",
         "deserialization",
         "Dockerfiles",
+        "Docsy",
+        "favicons",
         "flatbuffers",
+        "getenv",
         "Gmail",
         "gradlew",
         "Istio",
@@ -20,6 +22,7 @@
         "microservice",
         "microservices",
         "multicore",
+        "opengraph",
         "performant",
         "pluggable",
         "printf",

--- a/content/en/docs/languages/cpp/alts.md
+++ b/content/en/docs/languages/cpp/alts.md
@@ -1,5 +1,5 @@
 ---
-title: ALTS authentication in C++
+title: ALTS authentication
 short_title: ALTS
 description: >
   An overview of gRPC authentication in C++ using Application Layer Transport

--- a/content/en/docs/languages/go/alts.md
+++ b/content/en/docs/languages/go/alts.md
@@ -1,5 +1,5 @@
 ---
-title: ALTS authentication in Go
+title: ALTS authentication
 short_title: ALTS
 description: >
   An overview of gRPC authentication in Go using Application Layer Transport

--- a/content/en/docs/languages/go/generated-code.md
+++ b/content/en/docs/languages/go/generated-code.md
@@ -1,5 +1,5 @@
 ---
-title: Go Generated-code reference
+title: Generated-code reference
 short_title: Generated code
 weight: 95
 ---

--- a/content/en/docs/languages/java/alts.md
+++ b/content/en/docs/languages/java/alts.md
@@ -1,5 +1,5 @@
 ---
-title: ALTS authentication in Java
+title: ALTS authentication
 short_title: ALTS
 description: >
   An overview of gRPC authentication in Java using Application Layer Transport

--- a/content/en/docs/languages/java/generated-code.md
+++ b/content/en/docs/languages/java/generated-code.md
@@ -1,5 +1,5 @@
 ---
-title: Java generated-code reference
+title: Generated-code reference
 short_title: Generated code
 weight: 95
 spelling: cSpell:ignore buildscript classpath grpcexample motd srcs xolstice

--- a/content/en/docs/languages/python/alts.md
+++ b/content/en/docs/languages/python/alts.md
@@ -1,5 +1,5 @@
 ---
-title: ALTS authentication in Python
+title: ALTS authentication
 short_title: ALTS
 description: >
   An overview of gRPC authentication in Python using Application Layer Transport

--- a/content/en/docs/languages/python/generated-code.md
+++ b/content/en/docs/languages/python/generated-code.md
@@ -5,8 +5,6 @@ weight: 80
 spelling: cSpell:ignore docstrings
 ---
 
-## Introduction
-
 gRPC Python relies on the protocol buffers compiler (`protoc`) to generate
 code.  It uses a plugin to supplement the generated code by plain `protoc`
 with gRPC-specific code.  For a `.proto` service description containing

--- a/content/en/docs/languages/python/generated-code.md
+++ b/content/en/docs/languages/python/generated-code.md
@@ -1,5 +1,5 @@
 ---
-title: Python Generated-code reference
+title: Generated-code reference
 short_title: Generated code
 weight: 80
 spelling: cSpell:ignore docstrings

--- a/content/en/docs/platforms/android/kotlin/quickstart.md
+++ b/content/en/docs/platforms/android/kotlin/quickstart.md
@@ -1,6 +1,5 @@
 ---
-title: Quick start - Kotlin for Android
-short_title: Quick start
+title: Quick start
 description: This guide gets you started with Kotlin gRPC on Android with a simple working example.
 weight: 10
 ---

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,4 @@
 {{/* This file is in place as an override to the Docsy theme */}}
-
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
@@ -12,7 +11,15 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end */}}
 {{ partialCached "favicons.html" . }}
-<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ if in .File.Dir "docs/languages/" }}{{ .Parent.Title }} - {{ .Title }} | {{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ end }}{{ .Site.Title }}{{ end }}</title>
+<title>
+  {{- if not .IsHome -}}
+    {{ with .Title }}{{ . }} | {{ end -}}
+    {{ if findRE "^docs/(languages|platforms)/.+?/[^_]" .File.Path -}}
+      {{ with .Parent.Title }}{{ . }} | {{ end -}}
+    {{ end -}}
+  {{ end -}}
+  {{ .Site.Title -}}
+</title>
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}


### PR DESCRIPTION
- Fixes issue where .Parent.Title ("Documentation") was added to the Language and Platform page titles, and the language/platform-specific landing page titles
- Final work towards #363
- Cleanup (shorten) of page titles now that HTML-page titles are unique
- Contributes to #362

cc @aidanranney - note the changes to `layouts/partials/head.html`