### PR TITLE
Add redirect rule for /docs/guides/auth/ALTS (all caps)

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -5,6 +5,7 @@
 
 # ALTS page is now language-specific (#527); redirect to base auth page for now
 /docs/guides/auth/alts  /docs/guides/auth
+/docs/guides/auth/ALTS  /docs/guides/auth # https://github.com/grpc/grpc.io/issues/574
 
 # Languages -> platforms redirects
 


### PR DESCRIPTION
Closes #574

Redirect tests:
- https://deploy-preview-575--grpc-io.netlify.app/docs/guides/auth/alts
- https://deploy-preview-575--grpc-io.netlify.app/docs/guides/auth/ALTS