### PR TITLE
Comment files which are overriding Docsy or Hugo

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to the Docsy theme */}}
+
 {{/* cSpell:ignore URL's */}}
 {{ define "title" -}}
 404 Page not found &ndash; {{ site.Title -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -1,3 +1,4 @@
+{{/* This file is in place as an override to Docsy */}}
 
 {{ $auth  := .Params.author }}
 {{ $auths := .Params.authors }}

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 {{ define "main" }}
 {{ with .Content }}
 {{ . }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 {{ define "main" }}
 	<div class="td-content list-page">
 		<h1>{{ .Title }}</h1>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 {{ define "main" }}
 <h1 class="mb-4 font-weight-bold">{{ .Title }}</h1>
 <p class="lead pb-2">{{ .Description }}</p>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 <nav aria-label="breadcrumb" class="d-print-none">
 	<ol class="breadcrumb spb-1">
 		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}

--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 <link rel="shortcut icon" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" href="/favicons/android-chrome-192x192.png" sizes="192x192">

--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Docsy */}}
+
 {{ $inServerMode := site.IsServer }}
 {{ $includePaths := (slice "node_modules") }}
 {{ $scssMain := "scss/main.scss"}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,5 @@
-{{/* This file is in place as an override to the Docsy theme */}}
+{{/* This file is in place as an override to Docsy */}}
+
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to the Docsy theme */}}
+
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,3 +1,5 @@
+{{/* This file is in place as an override to Hugo's default */}}
+
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Overrides incur a degree of technical debt as they will need to be kept up to date when the Docsy theme is updated, if there are any conflicts or new functionality which needs to be migrated. If the need for an override or piece of customization disappears, the file can be safely deleted as Hugo which default to Docsy in its lookup order.

Keeping this on draft, pending a merge and rebase of #567 