### PR TITLE
Add new shortcode to add missing headings to ToC

### DIFF
--- a/content/en/docs/languages/cpp/_index.md
+++ b/content/en/docs/languages/cpp/_index.md
@@ -1,7 +1,6 @@
 ---
 title: C++
 prog_lang_home: true
-notoc: true
 src_repo: https://github.com/grpc/grpc
 content:
   - learn_more:
@@ -14,3 +13,5 @@ content:
   - other:
     - "[grpc repo]($src_repo_url)"
 ---
+
+{{% docs/prog-lang-home-content %}}

--- a/content/en/docs/languages/csharp/_index.md
+++ b/content/en/docs/languages/csharp/_index.md
@@ -15,3 +15,5 @@ content:
     - "[grpc repo]($src_repo_url)"
     - "[Daily builds](daily-builds)"
 ---
+
+{{% docs/prog-lang-home-content %}}

--- a/content/en/docs/languages/dart/_index.md
+++ b/content/en/docs/languages/dart/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Dart
 prog_lang_home: true
-notoc: true
 api_path: https://pub.dev/documentation/grpc
 content:
   - learn_more:
@@ -12,3 +11,5 @@ content:
     - $src_repo_link
     - "[pub package](https://pub.dev/packages/grpc)"
 ---
+
+{{% docs/prog-lang-home-content %}}

--- a/content/en/docs/languages/go/_index.md
+++ b/content/en/docs/languages/go/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Go
 prog_lang_home: true
-notoc: true
 api_path: https://pkg.go.dev/google.golang.org/grpc
 content:
   - learn_more:
@@ -19,7 +18,9 @@ content:
 spelling: cSpell:ignore Isberner Klerk Malte youtube
 ---
 
-#### Developer stories and talks {#dev-stories}
+{{% docs/prog-lang-home-content %}}
+
+### Developer stories and talks {#dev-stories}
 
 - **[Stubbing gRPC in Go](https://jadekler.github.io/2020/10/08/stubbing-grpc.html)**,
   by [Jean de Klerk](https://github.com/jadekler), Google. October 8, 2020.

--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Java
 prog_lang_home: true
-notoc: true
 spelling: cSpell:ignore javadoc Kanti Katirtzis Nikos Sharma Tomo Tuhin youtube Varun
 api_path: grpc-java/javadoc
 content:
@@ -18,7 +17,9 @@ content:
     - "[Download]($src_repo_url#download)"
 ---
 
-#### Developer stories and talks {#dev-stories}
+{{% docs/prog-lang-home-content %}}
+
+### Developer stories and talks {#dev-stories}
 
 - [Introducing gRPC to our Hotels.com Platform — Part 1][],
   by Nikos Katirtzis, Software Engineer, [Hotels.com][],

--- a/content/en/docs/languages/kotlin/_index.md
+++ b/content/en/docs/languages/kotlin/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Kotlin/JVM
 prog_lang_home: true
-notoc: true
 language: Kotlin
 api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
 content:
@@ -16,7 +15,9 @@ content:
 spelling: cSpell:ignore Ferrer youtube
 ---
 
-#### Developer stories and talks {#dev-stories}
+{{% docs/prog-lang-home-content %}}
+
+### Developer stories and talks {#dev-stories}
 
 - **Next Level gRPC With Kotlin and Coroutines**
   <a class="icon" href="https://youtu.be/SfmdAA2kwWI"><i class="fab fa-youtube"></i></a>

--- a/content/en/docs/languages/python/_index.md
+++ b/content/en/docs/languages/python/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Python
 prog_lang_home: true
-notoc: true
 src_repo: https://github.com/grpc/grpc
 content:
   - learn_more:
@@ -15,3 +14,5 @@ content:
     - "[grpc repo]($src_repo_url)"
     - "[Daily builds](daily-builds)"
 ---
+
+{{% docs/prog-lang-home-content %}}

--- a/layouts/partials/docs/prog-lang-home.html
+++ b/layouts/partials/docs/prog-lang-home.html
@@ -1,7 +1,4 @@
-{{ $lang := lower ($.Params.language | default $.Params.title) }}
 {{ $Lang := .Params.title | default .Params.language }}
-{{ $src_repo_url := $.Params.src_repo | default (printf "https://github.com/grpc/grpc-%s" $lang) }}
-{{ $src_repo_link := printf "[grpc-%s repo](%s)" $lang $src_repo_url }}
 
   <div class="row">
     <div class="col-sm col-md-6 mb-4 mb-md-0">
@@ -32,27 +29,6 @@
     </div>
     {{ end }}
   </div>
-  
-  <hr/>
-  {{ with .Params.content -}}
-    <div class="row o-lang-home__list">
-      {{ range $list_entry := . }}
-        {{ range $heading, $items := $list_entry }}
-          {{ $hd := printf "#### %s" (humanize $heading) -}}
-          <div class="col-12 col-md-4">
-            {{ $hd | $.Page.RenderString }}
-            <ul>
-              {{ range $items }}
-                {{ $item := replace . "$src_repo_url" $src_repo_url }}
-                {{ $item = replace $item "$src_repo_link" $src_repo_link }}
-                <li>{{ $item | $.Page.RenderString }}</li>
-              {{ end }}
-            </ul>
-          </div>
-        {{ end }}
-      {{ end }}
-    </div>
-  {{ end }}
   {{ with .Content }}
     <hr/>
     {{ . }}

--- a/layouts/shortcodes/docs/prog-lang-home-content.md
+++ b/layouts/shortcodes/docs/prog-lang-home-content.md
@@ -1,0 +1,25 @@
+{{ $lang := lower ($.Page.Params.language | default $.Page.Params.title) }}
+{{ $src_repo_url := $.Page.Params.src_repo | default (printf "https://github.com/grpc/grpc-%s" $lang) }}
+{{ $src_repo_link := printf "[grpc-%s repo](%s)" $lang $src_repo_url }}
+
+{{ with .Page.Params.content -}}
+<div class="row flex-col flex-md-row o-lang-home__list">
+{{ range $list_entry := . }}
+{{ range $heading, $items := $list_entry }}
+{{ $hd := printf "### %s" (humanize $heading) -}}
+<div class="col-12 col-md-4">
+
+{{ $hd }}
+
+<ul>
+{{ range $items }}
+  {{ $item := replace . "$src_repo_url" $src_repo_url }}
+  {{ $item = replace $item "$src_repo_link" $src_repo_link }}
+  <li>{{ $item | $.Page.RenderString }}</li>
+{{ end }}
+</ul>
+</div>
+{{ end }}
+{{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
Previously, the Markdown renderer was not being passed the headings to render on "language home" list pages. This moves some of the template logic into a shortcode and specifies that it should be rendered as Markdown. The shortcode is then called directly in the index pages.