### PR TITLE
Docsy changes/polish

### DIFF
--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -180,6 +180,11 @@ c - Component (Aware of its content/context...)
   }
 }
 
+.l-no-breadcrumb {
+  display: block;
+  margin-bottom: 3.25rem;
+}
+
 // Object
 .o-banner {
   width: 100%;

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -48,12 +48,16 @@ sections site wide to the original site's background svg.
 .td-toc {
   height: initial;
   padding-top: 4.75rem;
+
+  & ul {
+    margin-bottom: 0;
+  }
 }
 
 // Custom in-page toc. Apply this class as a modifier on top of the Docsy-provided .td-toc
 .td-toc--inline {
   padding-top: 0;
-  padding-bottom: 0;
+  padding-bottom: 1rem;
   border-left: none;
   position: static;
   height: auto;
@@ -68,30 +72,32 @@ sections site wide to the original site's background svg.
     overflow: hidden;
     min-height: 5rem;
     height: 5rem;
-
-    & + #td-content__toc-link--expanded::before {
-      content: "…";
-    }
   }
 
   & #td-content__toc.collapsing {
     height: 5rem;
   }
 
-  & #td-content__toc.collapse.show + #td-content__toc-link--expanded::before {
+  & #td-content__toc.collapse:not(.show) + #td-content__toc-link-expanded::before,
+  & #toc-contents.collapse:not(.show) + #td-content__toc-link-expanded::before {
+    content: "…";
+  }
+
+  & #td-content__toc.collapse.show + #td-content__toc-link-expanded::before,
+  & #toc-contents + #td-content__toc-link-expanded::before {
     content: "\2303";
   }
 }
 
-#td-content__toc-link span i.fa-chevron-up {
+#td-content__toc-link span i.fa-chevron-right {
   transition: transform 250ms ease-in-out;
 }
 
-#td-content__toc-link[aria-expanded="true"] span i.fa-chevron-up {
-  transform: rotate(-180deg);
+#td-content__toc-link[aria-expanded="true"] span i.fa-chevron-right {
+  transform: rotate(-90deg);
 }
 
-#td-content__toc-link--expanded {
+#td-content__toc-link-expanded {
   background-color: $gray-200;
 }
 

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -46,6 +46,9 @@
 
 		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
+	<div class="d-xl-none td-toc td-toc--inline d-print-none">
+		{{ partial "docs/toc-inline.html" . }}
+	</div>
 	{{ .Content }}
 	{{ if (.Site.Params.DisqusShortname) }}
 		<br />

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,10 +1,15 @@
 {{/* This file is in place as an override to Docsy */}}
 
+{{ if not .Parent.IsHome }}
 <nav aria-label="breadcrumb" class="d-print-none">
 	<ol class="breadcrumb spb-1">
 		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
 	</ol>
 </nav	>
+{{ else }}
+<div class="l-no-breadcrumb"></div>
+{{ end }}
+
 {{ define "breadcrumbnav" }}
 {{ if .p1.Parent }}
 {{ if not .p1.Parent.IsHome }}

--- a/layouts/partials/docs/toc-inline.html
+++ b/layouts/partials/docs/toc-inline.html
@@ -1,13 +1,13 @@
 {{ if not .Params.notoc }}
   {{ with .TableOfContents }}
     {{ if ge (len .) 200 }}
-      <a id="td-content__toc-link" href="#td-content__toc" class="lead font-weight-light" data-toggle="collapse" aria-controls="td-docs-toc" aria-expanded="false" aria-label="Toggle toc navigation">
-        <span>Contents<i class="fas fa-chevron-up ml-2"></i></span>
+      <a id="td-content__toc-link" href="#td-content__toc" data-toggle="collapse" aria-controls="td-docs-toc" aria-expanded="false" aria-label="Toggle toc navigation">
+        <span class="lead">Contents<i class="fas fa-chevron-right ml-2"></i></span>
       </a>
       <div id="td-content__toc" class="collapse">
         {{ . }}
       </div>
-      <button id="td-content__toc-link--expanded" href="#td-content__toc" class="btn btn-small ml-1 my-2 py-0 px-3" data-toggle="collapse" aria-controls="td-docs-toc" aria-expanded="true" aria-label="Toggle toc navigation">
+      <button id="td-content__toc-link-expanded" href="#td-content__toc" class="btn btn-small ml-1 my-2 py-0 px-3" data-toggle="collapse" aria-controls="td-docs-toc" aria-expanded="true" aria-label="Toggle toc navigation">
       </button>
     {{ end }}
   {{ end }}

--- a/layouts/shortcodes/page/toc.html
+++ b/layouts/shortcodes/page/toc.html
@@ -10,15 +10,14 @@
       <div class="td-toc td-toc--inline">
   {{ end }}
       {{ if $collapsed }}
-        <a id="td-content__toc-link" class="d-inline-flex collapsed" href="#toc-contents" data-toggle="collapse" aria-controls="td-page-toc" aria-expanded="false" aria-label="Toggle toc navigation">
-            <h5 class="lead"><i class="fas fa-list mr-2"></i>Page Contents</h5>
-            <span><i class="fas fa-chevron-up ml-2"></i></span>
+        <a id="td-content__toc-link" class="collapsed" href="#toc-contents" data-toggle="collapse" aria-controls="td-page-toc" aria-expanded="false" aria-label="Toggle toc navigation">
+          <span class="lead">Contents<i class="fas fa-chevron-right ml-2"></i></span>
         </a>
         <div id="toc-contents" class="collapse">
           {{ . }}
         </div>
       {{ else }}
-        <h5 class="lead"><i class="fas fa-list mr-2"></i>Page Contents</h5>
+        <h5 class="lead"><i class="fas fa-list mr-2"></i>Contents</h5>
         {{ partial "page-meta-links.html" $.Page }}
         <div class="text-left">
           {{ . }}


### PR DESCRIPTION
This moves to address the following issues (copied from the shared Google Doc):

- Docs in-page TOC: after "Content" use ">" when collapsed, and "^" when expanded

Documentation page:
- Don't show breadcrumb with single self-linking item

About & showcase on mobile:
- Currently only shows "Page Contents" w/o anything below it. (overflow bug)
- "Page Contents" → "Contents"
- Use same icons for collapsed/expanded as for doc pages
- Blog post pages should have in-page TOC too, like doc pages.

One note that is TBD is:
- Documentation page: Official support heading should be in TOC (either to be dropped, or generate a ToC with more than one heading)