### PR TITLE
Fix top blog 404s (2021/01)

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,4 +1,4 @@
-# cSpell:ignore channelz helloasync loadbalancing quickstart sapi vendasta vendastagrpc
+# cSpell:ignore channelz helloasync gablogpost loadbalancing quickstart sapi vendasta vendastagrpc vsco vscogrpc yygrpc yikyak
 
 # FAQ is now within the /docs/what-is-grpc section - redirect to maintain existing links
 /faq  /docs/what-is-grpc/faq
@@ -98,12 +98,17 @@
 
 /2017/08/22/grpc-go-perf-improvements*  /blog/grpc-go-perf-improvements
 /2018/01/22/grpc-go-engineering-practices*  /blog/grpc-go-engineering-practices
+/blog/2017-08-22-grpc-go-perf-improvements*  /blog/grpc-go-perf-improvements
 /blog/a_short_introduction_to_channelz*  /blog/a-short-introduction-to-channelz
+/blog/bazel_rules_protobuf*  /blog/bazel-rules-protobuf
 /blog/flatbuffers    /blog/grpc-flatbuffers
+/blog/gablogpost*  /blog/ga-announcement
 /blog/grpc_on_http2  /blog/grpc-on-http2
 /blog/http2_smarter_at_scale /blog/http2-smarter-at-scale
 /blog/loadbalancing  /blog/grpc-load-balancing
 /blog/vendastagrpc   /blog/vendasta
+/blog/vscogrpc*  /blog/vsco/
+/blog/yygrpc*  /blog/yikyak/
 /docs/guides/wire*   https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 /posts/* /blog/:splat
 


### PR DESCRIPTION
The top 404s for blog entries are for:

```
/blog/bazel_rules_protobuf
/blog/yygrpc
/blog/2017-08-22-grpc-go-perf-improvements
/blog/gablogpost
/blog/vscogrpc
```

Redirect tests:

- https://deploy-preview-602--grpc-io.netlify.app/blog/bazel_rules_protobuf
- https://deploy-preview-602--grpc-io.netlify.app/blog/yygrpc/
- https://deploy-preview-602--grpc-io.netlify.app/blog/2017-08-22-grpc-go-perf-improvements.html
- https://deploy-preview-602--grpc-io.netlify.app/blog/gablogpost-anything-after-the-initial-match
- https://deploy-preview-602--grpc-io.netlify.app/blog/vscogrpc
