### PR TITLE
Restore Docsy version to intended commit

### DIFF
--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -49,6 +49,9 @@
 	<div class="d-xl-none td-toc td-toc--inline d-print-none">
 		{{ partial "docs/toc-inline.html" . }}
 	</div>
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+		{{ partial "reading-time.html" . }}
+	{{ end }}
 	{{ .Content }}
 	{{ if (.Site.Params.DisqusShortname) }}
 		<br />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,14 +3,18 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+{{- $outputFormat := partial "outputformat.html" . -}}
+
 {{/* range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end */}}
+
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne $outputFormat "print") -}}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else -}}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end -}}
+
 {{ partialCached "favicons.html" . }}
 <title>
   {{- if not .IsHome -}}
@@ -30,8 +34,8 @@
 {{ end -}}
 {{ partialCached "head-css.html" . "asdf" }}
 <script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  src="https://code.jquery.com/jquery-3.5.1.min.js"
+  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
   crossorigin="anonymous"></script>
 {{ if .Site.Params.offlineSearch -}}
 <script
@@ -39,4 +43,8 @@
   integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
   crossorigin="anonymous"></script>
 {{ end -}}
-{{ partial "hooks/head-end.html" . -}}
+{{ if .Site.Params.prism_syntax_highlighting }}
+<!-- stylesheet for Prism -->
+<link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
+{{ end }}
+{{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -9,14 +9,24 @@
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
+  {{ else }}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
   {{ end }}
-  <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
+  <nav class="collapse td-sidebar-nav" id="td-section-nav">
     {{ if  (gt (len .Site.Home.Translations) 0) }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end }}
-    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "delayActive" $shouldDelayActive)  }}
   </nav>
 </div>
 {{ define "section-tree-nav-section" }}
@@ -41,23 +51,25 @@
       {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
       {{ $pages := $pages | first 50 }}
       {{ range $pages }}
-      {{ if .IsPage }}
-      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
-      {{ $active := eq . $p }}
-      {{ $isRedirected :=  findRE "^/docs/(languages|platforms)/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
-      {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
-      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}" {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}>
-        {{ if isset .Params "short_title" }}
-          {{ .Params.short_title }}
+      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) }}
+        {{ if .IsPage }}
+          {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+          {{ $active := eq . $p }}
+          {{ $isRedirected :=  findRE "^/docs/(languages|platforms)/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
+          {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
+          <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}" {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}>
+            {{ if isset .Params "short_title" }}
+              {{ .Params.short_title }}
+            {{ else }}
+              {{ .LinkTitle }}
+            {{ end }}
+            {{ if $isExternal -}}
+              <i class="fas fa-external-link-alt"></i>
+            {{- end -}}
+          </a>
         {{ else }}
-          {{ .LinkTitle }}
+          {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
         {{ end }}
-        {{ if $isExternal -}}
-          <i class="fas fa-external-link-alt"></i>
-        {{- end -}}
-      </a>
-      {{ else }}
-      {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
       {{ end }}
       {{ end }}
     </li>


### PR DESCRIPTION
This points the Docsy submodule to the original intended commit, and performs maintenance on customizations to the Docsy theme, incorporating theme updates to files which are currently overridden. Closes #603

For the full diff of changes to Docsy in this update, see:
https://github.com/google/docsy/compare/053672...f7fec42

Only one change was left out of the maintenance updates - a `d-lg-none` class on the search input in the `sidebar-tree.html` navigation [in Documentation section]. This hid the search input on larger screens. This class appears to be removed from Docsy on their master branch.

Other visual changes include an additional link being populated to the `page-meta-links` above the table of contents, and slightly reduced-width search inputs.