### PR TITLE
Showcase: render language dev-story buttons using markdown

### DIFF
--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -1,4 +1,4 @@
-/* 
+/*
 NOTE: Alterations to Docsy typically use a "td" namespace,
 styles which utilize this should be commented to make it clear
 what the workaround is for
@@ -125,7 +125,7 @@ body:not(.td-blog) .td-content:not(.list-page) {
   margin-right: 0.25rem;
 }
 
-// Fix to give rendered images width to match Docsy 
+// Fix to give rendered images width to match Docsy
 @include media-breakpoint-up(lg) {
   .td-content figure {
     max-width: 80%;
@@ -177,6 +177,15 @@ c - Component (Aware of its content/context...)
   h3 {
     margin-top: 2rem;
     margin-bottom: 1rem;
+  }
+}
+
+.l-dev-story-buttons {
+  @extend .l-buttons;
+  p { margin: 0; }
+  a {
+    @extend .btn;
+    @extend .btn-secondary;
   }
 }
 
@@ -233,7 +242,7 @@ c - Component (Aware of its content/context...)
   flex-direction: column;
 
   margin-bottom: 1.5rem;
-  padding-left: 1rem; 
+  padding-left: 1rem;
   padding-right: 1rem;
 
   h3 {

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -182,10 +182,20 @@ c - Component (Aware of its content/context...)
 
 .l-dev-story-buttons {
   @extend .l-buttons;
-  p { margin: 0; }
-  a {
-    @extend .btn;
-    @extend .btn-secondary;
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      display: inline;
+
+      a {
+        @extend .btn;
+        @extend .btn-secondary;
+        margin: 0.25rem;
+      }
+    }
   }
 }
 

--- a/content/en/showcase/_index.md
+++ b/content/en/showcase/_index.md
@@ -55,25 +55,14 @@ Developer stories cover a variety of technical subjects related to gRPC. You can
 find developer stories for your [preferred language](/docs/languages/) on each
 **language-specific landing page**.
 
-<div class="l-buttons">
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/go/#dev-stories">
-    Go
-  </a>
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/cpp/#dev-stories">
-    C++
-  </a>
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/java/#dev-stories">
-    Java
-  </a>
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/python/#dev-stories">
-    Python
-  </a>
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/csharp/#dev-stories">
-    C#
-  </a>
-  <a class="btn btn-light btn-lg font-weight-light" href="/docs/languages/">
-    <i class="fas fa-ellipsis-h"></i>
-  </a>
+<div class="l-dev-story-buttons">
+
+  [Go]({{< relref "go#dev-stories" >}})
+  [C++]({{< relref "cpp#dev-stories" >}})
+  [Java]({{< relref "/docs/languages/java#dev-stories" >}})
+  [Python]({{< relref "csharp#dev-stories" >}})
+  [C#]({{< relref "python#dev-stories" >}})
+  [<i class="fas fa-ellipsis-h"></i>]({{< relref "languages" >}})
 </div>
 
 Other developer stories are provided next.

--- a/content/en/showcase/_index.md
+++ b/content/en/showcase/_index.md
@@ -57,12 +57,12 @@ find developer stories for your [preferred language](/docs/languages/) on each
 
 <div class="l-dev-story-buttons">
 
-  [Go]({{< relref "go#dev-stories" >}})
-  [C++]({{< relref "cpp#dev-stories" >}})
-  [Java]({{< relref "/docs/languages/java#dev-stories" >}})
-  [Python]({{< relref "csharp#dev-stories" >}})
-  [C#]({{< relref "python#dev-stories" >}})
-  [<i class="fas fa-ellipsis-h"></i>]({{< relref "languages" >}})
+- [Go]({{< relref "go#dev-stories" >}})
+- [C++]({{< relref "cpp#dev-stories" >}})
+- [Java]({{< relref "/docs/languages/java#dev-stories" >}})
+- [Python]({{< relref "csharp#dev-stories" >}})
+- [C#]({{< relref "python#dev-stories" >}})
+- [<i class="fas fa-ellipsis-h"></i>]({{< relref "languages" >}})
 </div>
 
 Other developer stories are provided next.


### PR DESCRIPTION
Simplify `Showcase.md` by using markdown to generate the list of buttons linking to language-specific dev-story sections. Also slight "standardized" the button appearance. 