### PR TITLE
Alert shortcodes: treat all bodies as markdown

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -60,12 +60,12 @@ Google to power use cases from microservices to the "last mile" of computing
 For more background on why we created gRPC, see the [gRPC Motivation and Design
 Principles](/blog/principles/) on the [gRPC blog](/blog/).
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 <a name="officially-supported-languages-and-platforms"></a>
 
 Our table of **officially supported languages and platforms** has moved!
-See [Official support](/docs/#official-support).
-{{< /alert >}}
+See [Official support]({{<relref "docs#official-support">}}).
+{{% /alert %}}
 
 </div>
 

--- a/content/en/blog/grpc-web-interceptor.md
+++ b/content/en/blog/grpc-web-interceptor.md
@@ -47,10 +47,10 @@ The `StreamInterceptor` interface declaration is similar, except that the
 `invoker` return type is `ClientReadableStream` instead of `Promise`. For
 implementation details, see [interceptor.js][].
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   A `StreamInterceptor` can be applied to any RPC with a `ClientReadableStream`
   return type, whether it's a unary or a server-streaming RPC.
-{{< /alert >}}
+{{% /alert %}}
 
 ## What can I do with an interceptor?
 
@@ -182,12 +182,11 @@ const client = new MyServiceClient(
     host, creds, {'streamInterceptors': [interceptor1, interceptor2, interceptor3]});
 ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   Interceptors are executed in reverse order for request processing, and in
   order for response processing, as illustrated here:
-
   ![Interceptor processing order](/img/grpc-web-interceptors.png)
-{{< /alert >}}
+{{% /alert %}}
 
 ## Feedback
 

--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -44,11 +44,11 @@ The following authentication mechanisms are built-in to gRPC:
   most gRPC language implementations will not let you send credentials on an
   unencrypted channel.
 
-{{< alert title="Warning" color="warning" >}}
+{{% alert title="Warning" color="warning" %}}
   Google credentials should only be used to connect to Google services. Sending
   a Google issued OAuth2 token to a non-Google service could result in this
   token being stolen and used to impersonate the client to Google services.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Authentication API
 

--- a/content/en/docs/guides/benchmarking.md
+++ b/content/en/docs/guides/benchmarking.md
@@ -19,13 +19,13 @@ visualization.
   * [Multi-language performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584)
   * [C++ detailed performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5685265389584384)
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   Are you seeing "**no data available**" messages in the performance dashboard?
   This is a known issue, see [grpc/grpc#23297][].
 
   [grpc/grpc#23297]: https://github.com/grpc/grpc/issues/23297
 
-{{< /alert >}}
+{{% /alert %}}
 
 ### Performance testing design
 

--- a/content/en/docs/languages/cpp/basics.md
+++ b/content/en/docs/languages/cpp/basics.md
@@ -357,9 +357,9 @@ address and port we want to connect to - in our case we'll use no SSL:
 grpc::CreateChannel("localhost:50051", grpc::InsecureChannelCredentials());
 ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 In order to set additional options for the *channel*, use the `grpc::CreateCustomChannel()` api with any special channel arguments - `grpc::ChannelArguments`.
-{{< /alert >}}
+{{% /alert %}}
 
 Now we can use the channel to create our stub using the `NewStub` method provided in the `RouteGuide` class we generated from our .proto.
 

--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -141,11 +141,11 @@ the steps of the previous section.
     $ make -j
     ```
 
-    {{< alert title="Note" color="info" >}}
+    {{% alert title="Note" color="info" %}}
   **Getting build failures?** Most issues, at this point, are a result of a
   faulty installation. Ensure that the have the right versions of `cmake`, and
   carefully recheck your installation.
-    {{< /alert >}}
+    {{% /alert %}}
 
 ### Try it!
 
@@ -341,14 +341,14 @@ from the example **build** directory `examples/cpp/helloworld/cmake/build`:
     Greeter received: Hello again world
     ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   Interested in an **asynchronous** version of the client and server?
   You'll find the `greeter_async_{client,server}.cc` files in the
   [example's source directory][src].
 
   [src]: https://github.com/grpc/grpc/tree/master/examples/cpp/helloworld
 
-{{< /alert >}}
+{{% /alert %}}
 
 ### What's next
 

--- a/content/en/docs/languages/csharp/dotnet.md
+++ b/content/en/docs/languages/csharp/dotnet.md
@@ -13,10 +13,10 @@ The following pages cover the C# implementation of gRPC for .NET
 Several sample applications are available from the [examples][] folder in the
 [grpc-dotnet][] repository.
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   Looking for gRPC C# core-library documentation?
   See the [gRPC C# main page](..).
-{{< /alert >}}
+{{% /alert %}}
 
 [examples]: https://github.com/grpc/grpc-dotnet/tree/master/examples
 [grpc-dotnet]: https://github.com/grpc/grpc-dotnet

--- a/content/en/docs/languages/csharp/quickstart.md
+++ b/content/en/docs/languages/csharp/quickstart.md
@@ -4,12 +4,12 @@ description: This guide gets you started with gRPC in C# with a simple working e
 weight: 10
 ---
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   This page uses the [gRPC C# core-library][core-library] implementation. For
   documentation covering gRPC for .NET, see [gRPC for .NET](../dotnet/).
 
   [core-library]: https://github.com/grpc/grpc/tree/master/src/csharp
-{{< /alert >}}
+{{% /alert %}}
 
 ### Prerequisites
 
@@ -55,10 +55,10 @@ From the `examples/csharp/Helloworld` directory:
 > dotnet build Greeter.sln
 ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 If you want to use gRPC C# from a project that uses the "classic" .csproj files (supported by Visual Studio 2013, 2015 and older versions of Mono), please refer to the
 [Greeter using "classic" .csproj](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/csharp/HelloworldLegacyCsproj/README.md) example.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Run a gRPC application
 

--- a/content/en/docs/languages/dart/quickstart.md
+++ b/content/en/docs/languages/dart/quickstart.md
@@ -31,9 +31,9 @@ spelling: cSpell:ignore Iprotos
       $ export PATH="$PATH:$HOME/.pub-cache/bin"
       ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   Dart gRPC supports the Flutter and Server platforms.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Get the example code
 

--- a/content/en/docs/languages/go/basics.md
+++ b/content/en/docs/languages/go/basics.md
@@ -600,10 +600,10 @@ Got message Third message at point(0, 3)
 Got message Sixth message at point(0, 3)
 ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   We've omitted timestamps from the client and server trace output shown in this
   page.
-{{< /alert >}}
+{{% /alert %}}
 
 [download]: https://github.com/grpc/grpc-go/archive/{{< param grpc_vers.go >}}.zip
 [grpc-go]: https://github.com/grpc/grpc-go

--- a/content/en/docs/languages/java/quickstart.md
+++ b/content/en/docs/languages/java/quickstart.md
@@ -52,10 +52,10 @@ From the `examples` directory:
 
 Congratulations! You've just run a client-server application with gRPC.
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   We've omitted timestamps from the client and server trace output shown in this
   page.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Update the gRPC service
 

--- a/content/en/docs/languages/objective-c/basics.md
+++ b/content/en/docs/languages/objective-c/basics.md
@@ -223,11 +223,11 @@ In this section, we'll look at creating an Objective-C client for our
 `RouteGuide` service. You can see our complete example client code in
 [examples/objective-c/route_guide/ViewControllers.m](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/objective-c/route_guide/ViewControllers.m).
 
-{{< alert title="Note" color="info" >}}
-In your apps, for maintainability and readability reasons, you shouldn't
-put all of your view controllers in a single file; it's done here only to
-simplify the learning process).
-{{< /alert >}}
+{{% alert title="Note" color="info" %}}
+  In your apps, for maintainability and readability reasons, you shouldn't
+  put all of your view controllers in a single file; it's done here only to
+  simplify the learning process).
+{{% /alert %}}
 
 #### Constructing a service object
 

--- a/content/en/docs/languages/objective-c/oauth2.md
+++ b/content/en/docs/languages/objective-c/oauth2.md
@@ -46,7 +46,7 @@ expects Google account credentials, but neither gRPC nor the Objective-C client
 library is tied to any specific OAuth2 provider). The second view makes a gRPC
 request to the test server, using the access token obtained by the first view.
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 OAuth2 libraries need the application to register and obtain an ID from
 the identity provider (in the case of this example app, Google). The app's XCode
 project is configured using that ID, so you shouldn't copy this project "as is"
@@ -54,7 +54,7 @@ for your own app: it would result in your app being identified in the consent
 screen as "gRPC-AuthSample", and not having access to real Google services.
 Instead, configure your own XCode project following the [instructions
 here](https://developers.google.com/identity/sign-in/ios/).
-{{< /alert >}}
+{{% /alert %}}
 
 As with the other Objective-C examples, you also should have
 [CocoaPods](https://cocoapods.org/#install) installed, as well as the relevant

--- a/content/en/docs/languages/php/quickstart.md
+++ b/content/en/docs/languages/php/quickstart.md
@@ -74,9 +74,9 @@ or specific version
 sudo pecl install grpc-1.7.0
 ```
 
-{{< alert title="Warning" color="warning" >}}
+{{% alert title="Warning" color="warning" %}}
 This step unfortunately won’t work on CentOS/RHEL 6. Please follow the instructions below to compile the PECL extension from source.
-{{< /alert >}}
+{{% /alert %}}
 
 ##### Install on Windows
 

--- a/content/en/docs/languages/python/basics.md
+++ b/content/en/docs/languages/python/basics.md
@@ -162,9 +162,9 @@ than creates a new one. The generated code files are called
    - `add_RouteGuideServicer_to_server`, which adds a RouteGuideServicer to
      a `grpc.Server`
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 The `2` in pb2 indicates that the generated code is following Protocol Buffers Python API version 2. Version 1 is obsolete. It has no relation to the Protocol Buffers Language version, which is the one indicated by `syntax = "proto3"` or `syntax = "proto2"` in a .proto file.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Creating the server {#server}
 

--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -376,9 +376,9 @@ Run the server:
 $ bundle exec route_guide/route_guide_server.rb ../python/route_guide/route_guide_db.json
 ```
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
 The `route_guide_db.json` file is actually language-agnostic, it happens to be located in the `python` folder.
-{{< /alert >}}
+{{% /alert %}}
 
 From a different terminal, run the client:
 

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -24,11 +24,11 @@ weight: 10
 - An android device set up for [USB debugging][] or an
   [Android Virtual Device][]
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   gRPC Java does not support running a server on an Android device. For this
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Get the example code
 
@@ -83,10 +83,10 @@ The example code is part of the [grpc-java][] repo.
 
 Congratulations! You've just run a client-server application with gRPC.
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   We've omitted timestamps from the client and server trace output shown in this
   page.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Update the gRPC service
 

--- a/content/en/docs/platforms/android/kotlin/quickstart.md
+++ b/content/en/docs/platforms/android/kotlin/quickstart.md
@@ -25,11 +25,11 @@ weight: 10
 - An android device set up for [USB debugging][] or an
   [Android Virtual Device][]
 
-{{< alert title="Note" color="info" >}}
+{{% alert title="Note" color="info" %}}
   gRPC Kotlin does not support running a server on an Android device. For this
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
-{{< /alert >}}
+{{% /alert %}}
 
 ### Get the example code
 

--- a/content/en/docs/platforms/web/quickstart.md
+++ b/content/en/docs/platforms/web/quickstart.md
@@ -39,14 +39,14 @@ From the `grpc-web` directory:
     $ docker-compose pull
     ```
 
-    {{< alert title="Note" color="info" >}}
+    {{% alert title="Note" color="info" %}}
 Getting the following warning? You can ignore it for the purpose of running the
 example app:
 
 ```nocode
 WARNING: Some service image(s) must be built from source
 ```
-    {{< /alert >}}
+    {{% /alert %}}
 
  2. Launch services as background processes:
 

--- a/content/en/docs/protoc-installation.md
+++ b/content/en/docs/protoc-installation.md
@@ -19,7 +19,7 @@ to install `protoc`.
 You can install the protocol compiler, `protoc`, with a package manager under
 Linux or macOS using the following commands.
 
-{{< alert title="Warning" color="warning" >}}
+{{% alert title="Warning" color="warning" %}}
   **Check the version of `protoc`** (as indicated below) after installation to
   ensure that it is sufficiently recent. The versions of `protoc` installed by
   some package managers can be quite dated.
@@ -27,7 +27,7 @@ Linux or macOS using the following commands.
   Installing from pre-compiled binaries, as indicated in the [next
   section](#binary-install), is the best way to ensure that you're using the
   latest release of `protoc`.
-{{< /alert >}}
+{{% /alert %}}
 
 - Linux, using `apt` or `apt-get`, for example:
 

--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -188,9 +188,9 @@ complete before a client has sent all its requests.
 Either the client or the server can cancel an RPC at any time. A cancellation
 terminates the RPC immediately so that no further work is done.
 
-{{< alert title="Warning" color="warning" >}}
+{{% alert title="Warning" color="warning" %}}
   Changes made before a cancellation are not rolled back.
-{{< /alert >}}
+{{% /alert %}}
 
 #### Metadata
 


### PR DESCRIPTION
Contributes to #623

As an example of what this fixes, consider the **Note** at the end of the section at https://grpc.io/docs/languages/cpp/quickstart/#run:

- Before:
  > <img src="https://user-images.githubusercontent.com/4140793/107536460-cb493500-6b8f-11eb-8639-ae8255882cd3.png" width=500>

- After:
  > <img src="https://user-images.githubusercontent.com/4140793/107536512-da2fe780-6b8f-11eb-8fc1-1f687bbae340.png" width=500>


Notice that the render-link hook kicks in -- the external link has an external link icon and the link opens in a blank target.