### PR TITLE
Community page: minor cleanup of styles etc

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,4 +1,4 @@
-// Import any new stylesheets here
+// This file is in place as an override to Docsy
 
 @import "support/functions";
 @import "variables";
@@ -51,10 +51,7 @@ footer {
     visibility: hidden;
   }
 
-  h2[id]:before,
-  h3[id]:before,
-  h4[id]:before,
-  h5[id]:before {
+  h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before {
     display: block;
     content: " ";
     margin-top: -5rem;

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -35,7 +35,7 @@ other_channels:
     desc: >
       Consult the [`r/grpc`](https://www.reddit.com/r/grpc/) subreddit for
       discussions related to gRPC.
-meetup:
+community_resources:
   - title: >
       <a href="https://www.meetup.com/gRPCio/"
         target="_blank" rel="noopener"><i class="fab
@@ -57,11 +57,6 @@ meetup:
       Missed a meeting? No problem. Visit the [gRPC channel][grpc-youtube] for
       meeting videos.
 ---
-
-<style>
-h2 { padding: 1rem 0 !important; }
-h3 { padding: 0.5rem 0 !important; }
-</style>
 
 {{< blocks/cover color="primary" height="sm" >}}
 {{< page/header >}}
@@ -86,8 +81,6 @@ and building valuable integrations of gRPC with other software systems.
   [Code of Conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 {{% /alert %}}
 
-
-
 ## Stay informed
 
 Be the first to know! Follow these active channels for the gRPC announcements:
@@ -109,7 +102,7 @@ exchange with developers and find answers to your gRPC questions:
 Get fresh news, and come talk with gRPC developers and other community members
 at one of our regular online community meetings.
 
-{{% cards "meetup" %}}
+{{% cards "community_resources" %}}
 
 ## Contribute
 
@@ -145,10 +138,10 @@ Ecosystem Project Request][].
 [grpc-ecosystem-how-to]: https://github.com/grpc/grpc-community/blob/master/grpc_ecosystem.md
 [grpc-io]: https://groups.google.com/forum/#!forum/grpc-io
 [grpc-tag]: https://stackoverflow.com/questions/tagged/grpc
+[grpc-youtube]: https://www.youtube.com/channel/UCrnk1HWelWnYtF78YZX80fg
 [gRPCio]: https://www.meetup.com/gRPCio/
-[meeting-doc]: https://bit.ly/grpcmeetings
 [language]: {{< relref "languages" >}}
 [mailing list]: https://groups.google.com/forum/#!forum/grpc-io
+[meeting-doc]: https://bit.ly/grpcmeetings
 [platform]: {{< relref "platforms" >}}
 [protoc-tag]: https://stackoverflow.com/questions/tagged/protoc
-[grpc-youtube]: https://www.youtube.com/channel/UCrnk1HWelWnYtF78YZX80fg


### PR DESCRIPTION
This fixes jumping to a page anchor -- the page offset was off because of the custom styling in this page. Removing them for now, will address later, if we opt for custom styling for the page headings.

Contributes to #618. Followup to #644

Preview: https://deploy-preview-645--grpc-io.netlify.app/community/