### PR TITLE
Blog posts: drop invalid & unnecessary Hugo aliases

### DIFF
--- a/content/en/blog/beta-release.md
+++ b/content/en/blog/beta-release.md
@@ -3,7 +3,6 @@ title: gRPC releases Beta, opening door for use in production environments
 date: 2015-10-26
 author:
   name: Mugur Marculescu
-aliases: ["blog/beta_release"]
 ---
 
 The gRPC team is excited to announce the immediate availability of gRPC Beta. This release marks an important point in API stability and going forward most API changes are expected to be additive in nature. This milestone opens the door for gRPC use in production environments.

--- a/content/en/blog/ga-announcement.md
+++ b/content/en/blog/ga-announcement.md
@@ -7,7 +7,6 @@ author:
   link: https://cloud.google.com
   blurb: Originally written by Varun Talwar with additional content by Kailash Sethuraman and others at Google.
 thumbnail: ../img/gcp-icon.png?raw=true
-aliases: ["blog/gablogpost"]
 ---
 
 Today, the gRPC project has reached a significant milestone with its [1.0 release](https://github.com/grpc/grpc/releases).

--- a/content/en/blog/vendasta.md
+++ b/content/en/blog/vendasta.md
@@ -7,7 +7,6 @@ author:
   guest: true
   blurb: Originally written by Dale Hopkins with additional content by Lisa Carey and others at Google
 thumbnail: /img/vend-icon.png?raw=true
-aliases: ["blog/vendastagrpc"]
 ---
 
 

--- a/content/en/blog/vsco.md
+++ b/content/en/blog/vsco.md
@@ -9,10 +9,9 @@ authors:
 blurb: |
   Thanks to the VSCO engineers that worked on this migration: Steven Tang, Sam Bobra, Daniel Song, Lucas Kacher, and many others.
 thumbnail: ../img/vsco-logo.png?raw=true
-aliases: ["blog/vscogrpc"]
 ---
 
-Our guest post today comes from Robert Sayre and Melinda Lu of VSCO. 
+Our guest post today comes from Robert Sayre and Melinda Lu of VSCO.
 
 Founded in 2011, [VSCO](https://vsco.co) is a community for expression—empowering people to create, discover and connect through images and words. VSCO is in the process of migrating their stack to gRPC.
 
@@ -30,12 +29,12 @@ As a first step in bringing gRPC to our mobile clients, we’ve shipped telemetr
 
 One slight roadblock we ran into was the need for our clients to maintain compatibility with our JSON implementation as we ramp up, and for integration with vendor SDKs. This required a little bit of key-value coding on iOS, but it got more difficult on Android. We ended up having to write a protobuf compiler plugin to get the reflection features we needed while maintaining adequate performance. Drawing from that experience, we’ve made a concise [example protoc plugin](https://github.com/vsco/protoc-demo) built with [Bazel](https://bazel.io/) available on GitHub.
 
-As more and more of our data becomes available in protocol buffer form, we plan to build upon this unified schema to expand our machine-learning and analytics systems. For example, we write our Kafka database replication streams to Amazon S3 as [Apache Parquet](https://parquet.apache.org/), an efficient columnar disk-storage format. Parquet has low-level support for protocol buffers, so we can use our existing data definitions to write optimized tables and do partial deserializations where desired. 
+As more and more of our data becomes available in protocol buffer form, we plan to build upon this unified schema to expand our machine-learning and analytics systems. For example, we write our Kafka database replication streams to Amazon S3 as [Apache Parquet](https://parquet.apache.org/), an efficient columnar disk-storage format. Parquet has low-level support for protocol buffers, so we can use our existing data definitions to write optimized tables and do partial deserializations where desired.
 
 From S3, we run computations on our data using Apache Spark, which can use our protocol buffer definitions to define types. We’re also building new machine-learning applications with [TensorFlow](https://www.tensorflow.org/). It uses protocol buffers natively and allows us to serve our models as gRPC services with [TensorFlow Serving](https://tensorflow.github.io/serving/).
 
 So far, we’ve had good luck with gRPC and Protocol Buffers. They don’t eliminate every integration headache. However it’s easy to see how they help our engineers avoid writing a lot of boilerplate RPC code, while side-stepping the endless data-quality papercuts that come with looser serialization formats.
 
- 
+
 
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -100,6 +100,7 @@
 /2018/01/22/grpc-go-engineering-practices*  /blog/grpc-go-engineering-practices
 /blog/2017-08-22-grpc-go-perf-improvements*  /blog/grpc-go-perf-improvements
 /blog/a_short_introduction_to_channelz*  /blog/a-short-introduction-to-channelz
+/blog/beta_release*  /blog/beta-release
 /blog/bazel_rules_protobuf*  /blog/bazel-rules-protobuf
 /blog/flatbuffers    /blog/grpc-flatbuffers
 /blog/gablogpost*  /blog/ga-announcement


### PR DESCRIPTION
Closes #648 by removing the Hugo `aliases` entries from the front matter of affected blog pages. This allowed me to notice that a redirect rule was missing so I added it.

Redirect rule test:
- https://deploy-preview-649--grpc-io.netlify.app/blog/beta_release --> beta-release succeeds.

The following invalid redirect rule will no longer work:
- https://deploy-preview-649--grpc-io.netlify.app/blog/blog/beta_release/ --> 404

  ```console
  grpc.io > curl -I https://deploy-preview-649--grpc-io.netlify.app/blog/blog/beta_release/
  HTTP/2 404 
  ```

  Whereas previously, this was the result:

  ```console
  > curl -I https://grpc.io/blog/blog/beta_release
  HTTP/2 301 
  ```
