### PR TITLE
Add robots.txt

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ pygmentsCodeFences: true
 theme: ['docsy']
 
 enableGitInfo: true
+enableRobotsTXT: true
 
 contentDir: 'content/en'
 defaultContentLanguage: 'en'

--- a/content/en/docs/languages/csharp/daily-builds.md
+++ b/content/en/docs/languages/csharp/daily-builds.md
@@ -1,5 +1,6 @@
 ---
 title: Daily builds
+robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/php/daily-builds.md
+++ b/content/en/docs/languages/php/daily-builds.md
@@ -1,5 +1,6 @@
 ---
 title: Daily builds
+robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/python/daily-builds.md
+++ b/content/en/docs/languages/python/daily-builds.md
@@ -1,5 +1,6 @@
 ---
 title: Daily builds
+robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/ruby/daily-builds.md
+++ b/content/en/docs/languages/ruby/daily-builds.md
@@ -1,5 +1,6 @@
 ---
 title: Daily builds
+robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /get_grpcurl
+{{ range .Pages -}}
+{{ if in (lower .Params.robots) "noindex" -}}
+Disallow: {{ .RelPermalink }}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
- Closes #647 -- by fixing the remaining Google Search Console warnings and errors that we'll be addressing
- Closes #650
- Closes #651

cc @ejona86 

This is the `robots.txt` that currently gets generated, as [you can see from the preview server](https://deploy-preview-652--grpc-io.netlify.app/robots.txt):

```nocode
User-agent: *
Disallow: /get_grpcurl
Disallow: /docs/languages/csharp/daily-builds/
Disallow: /docs/languages/php/daily-builds/
Disallow: /docs/languages/python/daily-builds/
Disallow: /docs/languages/ruby/daily-builds/
Disallow: /docs/quickstart/
Disallow: /docs/tutorials/
```