### PR TITLE
Go generated code ref: change the message type name

### DIFF
--- a/content/en/docs/languages/go/generated-code.md
+++ b/content/en/docs/languages/go/generated-code.md
@@ -144,7 +144,7 @@ In this context, `<ServiceName>_FooClient` represents the client-to-server `stre
 ```go
 type <ServiceName>_FooClient interface {
 	Send(*MsgA) error
-	CloseAndRecv() (*MsgA, error)
+	CloseAndRecv() (*MsgB, error)
 	grpc.ClientStream
 }
 ```


### PR DESCRIPTION
The type of return message of `CloseAndRecv` can be different from the parameter type of `Send`.