### PR TITLE
Use grpc-docsy branch from a forked docsy repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
-	url = https://github.com/google/docsy.git
+	url = https://github.com/chalin/docsy.git
+	branch = grpc-docsy


### PR DESCRIPTION
Use of the github.com/chalin/docsy.git fork is temporary.