### PR TITLE
Node basics: replace deprecated method

### DIFF
--- a/content/en/docs/languages/node/basics.md
+++ b/content/en/docs/languages/node/basics.md
@@ -327,7 +327,7 @@ do this for our `RouteGuide` service:
 ```js
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(routeguide.RouteGuide.service, {
+  server.addService(routeguide.RouteGuide.service, {
     getFeature: getFeature,
     listFeatures: listFeatures,
     recordRoute: recordRoute,


### PR DESCRIPTION
Replace addProtoService with addService. I also submitted a PR to change the example code.