### PR TITLE
Build tweaks now that we're using hugo.IsProduction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ clean:
 
 serve:
 	@./check_hugo.sh
-	hugo server
+	hugo serve
 
 serve-drafts:
 	@./check_hugo.sh
-	hugo server $(DRAFT_ARGS)
+	hugo serve $(DRAFT_ARGS)
 
 serve-production: clean
 	@./check_hugo.sh
-	hugo server --minify
+	hugo serve -e production --minify
 
 production-build: clean
 	@./check_hugo.sh
@@ -25,7 +25,8 @@ production-build: clean
 
 preview-build: clean
 	@./check_hugo.sh
-	hugo --baseURL $(DEPLOY_PRIME_URL) $(BUILD_ARGS)
+	hugo --baseURL $(DEPLOY_PRIME_URL) \
+		-e development $(BUILD_ARGS)
 
 link-checker-setup:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,3 @@ command = "git submodule update --init --recursive --depth 1 && make preview-bui
 
 [context.deploy-preview]
 command = "git submodule update --init --recursive --depth 1 && make preview-build"
-
-[context.production.environment]
-HUGO_ENV = "production"


### PR DESCRIPTION
The `grpc-docy` now includes the following fix: https://github.com/google/docsy/pull/413 -- so I'm tweaking build scripts. Some more context is provided by https://github.com/gohugoio/hugo/issues/6873#issuecomment-784557603:

> `production` is the default environment you get when running `hugo`, `development` when running the server.

Contributes to #610