### PR TITLE
Make homepage mobile-friendly: fix used-by icon overflow

### DIFF
--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -295,9 +295,10 @@ c - Component (Aware of its content/context...)
   }
 }
 
-@include media-breakpoint-up(md) {
+@include media-breakpoint-down(md) {
   .o-user-logo {
-    max-height: 7rem;
+    max-height: 5rem;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Closes #689

Before:

> <img src="https://user-images.githubusercontent.com/4140793/109335648-5719bd00-7830-11eb-8fbc-3560b1608944.png" width=200>

> <img src="https://user-images.githubusercontent.com/4140793/109675709-0531a980-7b46-11eb-98e5-63681df9ebfd.png" width=200>


After:

> <img src="https://user-images.githubusercontent.com/4140793/109675526-e3d0bd80-7b45-11eb-973f-1d6644ee473f.png" width=200>

> <img src="https://user-images.githubusercontent.com/4140793/109675818-1f6b8780-7b46-11eb-948a-2b059dae6ac7.png" width=200>
