### PR TITLE
Change a message name that was also a keyword

### DIFF
--- a/content/en/docs/what-is-grpc/introduction.md
+++ b/content/en/docs/what-is-grpc/introduction.md
@@ -82,7 +82,7 @@ message HelloRequest {
 
 // The response message containing the greetings
 message HelloReply {
-  string message = 1;
+  string greeting = 1;
 }
 ```
 


### PR DESCRIPTION
It's being picked up by the syntax highlighter the same way as all `message` keywords, so was a bit distracting.