### PR TITLE
SCSS: fix the relative import order of variables and variables_project

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
         "Disqus",
         "Dockerfiles",
         "Docsy",
+        "Docsy's",
         "favicons",
         "flatbuffers",
         "getenv",

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -4,11 +4,16 @@ $secondary: #5ac5c5;
 $info: #379c9c;
 $gray-100: #fafafa;
 
-// Display styles: prefer Bootstrap defaults to docsy's overrides
-$display1-weight: $font-weight-light;
-$display2-weight: $font-weight-light;
-$display3-weight: $font-weight-light;
-$display4-weight: $font-weight-light;
+// Forward definitions of Bootstrap and Docsy variables
+// TODO: add value checks later in the import chain
+
+$_font-weight-light: 300;
+
+// Display styles: prefer Bootstrap defaults to Docsy's overrides
+$display1-weight: $_font-weight-light;
+$display2-weight: $_font-weight-light;
+$display3-weight: $_font-weight-light;
+$display4-weight: $_font-weight-light;
 
 $link-color: #379c9c;
 


### PR DESCRIPTION
Fixes #668. Note that this results in color corrections of derived color-variable values -- like the link hover color.