### PR TITLE
SCSS: use styles_project.scss rather than edit Docsy's main.scss

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,3 @@
+/* grpc-docsy full file override: we're not tracking changes to the docsy file of the same name. */
+
+@import "grpc";


### PR DESCRIPTION
There is no essential change to the generated site.