### PR TITLE
docs: update protoc version from 3.13.0 to 3.15.5

### DIFF
--- a/content/en/docs/protoc-installation.md
+++ b/content/en/docs/protoc-installation.md
@@ -2,7 +2,7 @@
 title: Protocol Buffer Compiler Installation
 short_title: Protoc Installation
 description: How to install the protocol buffer compiler.
-protoc-version: 3.13.0
+protoc-version: 3.15.5
 toc_hide: true
 ---
 


### PR DESCRIPTION
Update the `protoc` version of [Protocol Buffer Compiler Installation](https://grpc.io/docs/protoc-installation/) from 3.13.0 to latest 3.15.5