### PR TITLE
Switch to grpc/grpc.io-docsy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
-	url = https://github.com/chalin/docsy.git
-	branch = grpc-docsy
+	url = https://github.com/grpc/grpc.io-docsy.git
+	branch = grpc.io


### PR DESCRIPTION
Switch from:

- https://github.com/chalin/docsy, which was temporary

to

- https://github.com/grpc/grpc.io-docsy

The branch to be used for grpc.io is named `grpc.io`.

Closes  #669

---

After fetching this change, you may need to run the following commands on your local repo:

```console
$ git submodule sync --recursive
Synchronizing submodule url for 'themes/docsy'
Synchronizing submodule url for 'themes/docsy/assets/vendor/Font-Awesome'
Synchronizing submodule url for 'themes/docsy/assets/vendor/bootstrap'
$ git submodule update --init --recursive
```

@nate-double-u /cc @zacharysarah 