### PR TITLE
Footer: link to Terms, Privacy, License, etc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ enableGitInfo: true
 enableRobotsTXT: true
 
 params:
-  copyright: gRPC Authors & The Linux Foundation®
+  copyright: gRPC Authors
   repo: &repo https://github.com/grpc/grpc.io
   github_repo: *repo
   github_project_repo: *repo

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ enableGitInfo: true
 enableRobotsTXT: true
 
 params:
-  copyright: The gRPC Authors & The Linux Foundation® | Documentation CC BY 4.0.
+  copyright: gRPC Authors & The Linux Foundation®
   repo: &repo https://github.com/grpc/grpc.io
   github_repo: *repo
   github_project_repo: *repo

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,56 @@
+{{/* grpc-docsy file override */ -}}
+{{ $links := .Site.Params.links }}
+<footer class="bg-dark py-5 row d-print-none">
+  <div class="container-fluid mx-sm-5">
+    <div class="row">
+      <div class="col-6 col-sm-4 text-xs-center order-sm-2">
+        {{ with $links }}
+        {{ with index . "user"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
+        {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
+        {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ . }}
+          <!-- {{ T "footer_all_rights_reserved" }} -->
+        </small>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+        {{ if not .Site.Params.ui.footer_about_disable }}
+          {{ with .Site.GetPage "about" -}}
+            <p class="mt-2 text-white"><a href="{{ .RelPermalink }}">{{ .Title }}</a> |
+              <a href="#">Trademarks</a> |
+              <a href="#">Terms</a>
+            </p>
+          {{- end }}
+        {{ end }}
+      </div>
+    </div>
+    <div class="row text-center text-white small">
+      <div class="col-12 text-center py-2 order-sm-2">
+        <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank" rel="noopener">Trademarks</a> |
+        <a href="https://www.linuxfoundation.org/terms" target="_blank" rel="noopener">Terms</a> |
+        <a href="https://www.linuxfoundation.org/privacy" target="_blank" rel="noopener">Privacy</a> |
+        <a href="https://github.com/grpc/grpc.io/blob/main/LICENSE" target="_blank" rel="noopener">License</a> |
+        <a href="/about/">About</a>
+      </div>
+    </div>
+  </div>
+</footer>
+{{ define "footer-links-block" }}
+<ul class="list-inline mb-0">
+  {{ range . }}
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-white" target="_blank" rel="noopener noreferrer" href="{{ .url }}">
+      <i class="{{ .icon }}"></i>
+    </a>
+  </li>
+  {{ end }}
+</ul>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,9 +34,9 @@
     </div>
     <div class="row text-center text-white small">
       <div class="col-12 text-center py-2 order-sm-2">
-        <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank" rel="noopener">Trademarks</a> |
         <a href="https://www.linuxfoundation.org/terms" target="_blank" rel="noopener">Terms</a> |
         <a href="https://www.linuxfoundation.org/privacy" target="_blank" rel="noopener">Privacy</a> |
+        <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank" rel="noopener">Trademarks</a> |
         <a href="https://github.com/grpc/grpc.io/blob/main/LICENSE" target="_blank" rel="noopener">License</a> |
         <a href="/about/">About</a>
       </div>


### PR DESCRIPTION
- This PR streamlines the website footer and brings it closer to the [CNCF website guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md).
- Closes #660 

Preview: https://deploy-preview-716--grpc-io.netlify.app

### Current footer

> <img src="https://user-images.githubusercontent.com/4140793/110644735-64fe0500-8183-11eb-8c4b-1dc37e820ecf.png" width=800>

### New and improved footer

> <img src="https://user-images.githubusercontent.com/4140793/110697241-13bd3800-81ba-11eb-9068-97ec15f4d8c5.png" width=800>

---

Note that `layouts/partials/footer.html` will be moved to `grpc.io-docsy` in a followup PR.