### PR TITLE
Fix small spelling mistake on core concepts, architecture and lifecycle page

### DIFF
--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -172,7 +172,7 @@ or how much time is left to complete the RPC.
 
 Specifying a deadline or timeout is language specific: some language APIs work
 in terms of timeouts (durations of time), and some language APIs work in terms
-of a deadline (a fixed point in time) and may or maynot have a default deadline.
+of a deadline (a fixed point in time) and may or may not have a default deadline.
 
 #### RPC termination
 


### PR DESCRIPTION
It looks like there was a small typo in the [Deadlines/Timeouts](https://grpc.io/docs/what-is-grpc/core-concepts/#deadlines) section on the core concepts, architecture and lifecycle page.

I did a quick check to make sure that _maynot_ wasn't a term that I hadn't heard of (in case it wasn't a mistake) but I couldn't find anything that indicated that.