### PR TITLE
Don't generate daily-build placeholder pages

### DIFF
--- a/content/en/docs/languages/csharp/daily-builds.md
+++ b/content/en/docs/languages/csharp/daily-builds.md
@@ -3,4 +3,5 @@ title: Daily builds
 robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/php/daily-builds.md
+++ b/content/en/docs/languages/php/daily-builds.md
@@ -3,4 +3,5 @@ title: Daily builds
 robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/python/daily-builds.md
+++ b/content/en/docs/languages/python/daily-builds.md
@@ -3,4 +3,5 @@ title: Daily builds
 robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/ruby/daily-builds.md
+++ b/content/en/docs/languages/ruby/daily-builds.md
@@ -3,4 +3,5 @@ title: Daily builds
 robots: noindex, nofollow
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -48,7 +48,7 @@
 # Daily-build pages:
 #
 
-/docs/languages/:_/daily-builds/*  https://packages.grpc.io 301!
+/docs/languages/:_/daily-builds/*  https://packages.grpc.io
 
 /docs/talks  /showcase
 


### PR DESCRIPTION
Preview: for example, see

- https://deploy-preview-732--grpc-io.netlify.app/docs/languages/csharp/

Note how **Daily builds** still shows up in the left nav, and the link still redirects as expected:

> <img width="600" alt="Screen Shot 2021-03-22 at 12 03 07" src="https://user-images.githubusercontent.com/4140793/112020539-cf5d6080-8b06-11eb-902c-ed88b0bac243.png">
