### PR TITLE
PHP language-home: use new layout & link to examples

### DIFF
--- a/content/en/docs/languages/php/_index.md
+++ b/content/en/docs/languages/php/_index.md
@@ -1,12 +1,17 @@
 ---
 title: PHP
 api_path: grpc/LANG/namespace_grpc
-notoc: true
+prog_lang_home: true
+src_repo: https://github.com/grpc/grpc
+content:
+  - learn_more:
+    - "[Examples]($src_repo_url/tree/master/examples/php)"
+  - reference:
+    - "[API](api/)"
+  - other:
+    - "[grpc repo]($src_repo_url)"
+    - "[Daily builds](daily-builds)"
 ---
 
-These language-specific pages are available:
+{{% docs/prog-lang-home-content %}}
 
-- [Quick start](quickstart/)
-- [Basics tutorial](basics/)
-- [API reference](api)
-- [Daily builds](daily-builds)


### PR DESCRIPTION
Contributes to #481, #345

Preview: https://deploy-preview-734--grpc-io.netlify.app/docs/languages/php/

Screenshot:

> ![image](https://user-images.githubusercontent.com/4140793/112028873-06377480-8b0f-11eb-81d8-bc23eb415f57.png)
