### PR TITLE
Update basics.md

### DIFF
--- a/content/en/docs/languages/node/basics.md
+++ b/content/en/docs/languages/node/basics.md
@@ -44,6 +44,14 @@ example too.
 To download the example, clone the `grpc` repository by running the following
 command:
 
+Not sure what version should be here, but I got the following error running the Node RouteGuide example with v1.35.0:
+```sh
+node ./dynamic_codegen/route_guide/route_guide_server.js --db_path=./dynamic_codegen/route_guide/route_guide_db.json
+/home/dan/Sandbox/grpc/examples/node/node_modules/@grpc/grpc-js/build/src/server.js:72
+        throw new Error('Not implemented. Use addService() instead');
+        ^
+```
+
 ```sh
 $ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 $ cd grpc


### PR DESCRIPTION
I got the following error when using the grpc repository version recommended in the documentation. I pulled origin/master and everything worked fine. Not sure which version to suggest but I don't think it's v1.35.0. :)

```sh
node ./dynamic_codegen/route_guide/route_guide_server.js --db_path=./dynamic_codegen/route_guide/route_guide_db.json
/home/dan/Sandbox/grpc/examples/node/node_modules/@grpc/grpc-js/build/src/server.js:72
        throw new Error('Not implemented. Use addService() instead');
        ^
```