### PR TITLE
docs: node quickstart.md

### DIFF
--- a/content/en/docs/languages/node/quickstart.md
+++ b/content/en/docs/languages/node/quickstart.md
@@ -19,10 +19,12 @@ and other tutorials):
 ```sh
 # Clone the repository to get the example code
 $ git clone -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
-# Navigate to the dynamic codegen "hello, world" Node example:
-$ cd grpc/examples/node/dynamic_codegen
+# Navigate to the node example
+$ cd grpc/examples/node
 # Install the example's dependencies
 $ npm install
+# Navigate to the dynamic codegen "hello, world" Node example:
+$ cd dynamic_codegen
 ```
 
 ### Run a gRPC application


### PR DESCRIPTION
`npm install` should in the `examples/node` not `examples/node/dynamic_codegen`

![image](https://user-images.githubusercontent.com/13595509/115187167-b7421800-a097-11eb-920c-1e529fc917d4.png)
