### PR TITLE
Make CNCF shortcode a bit more generic

### DIFF
--- a/layouts/shortcodes/home/cncf.html
+++ b/layouts/shortcodes/home/cncf.html
@@ -1,5 +1,5 @@
 <section class="home--top-section">
-<h4>gRPC is a <a href="https://cncf.io">CNCF</a> incubation project</h4>
+<h4>{{ .Site.Title }} is a <a href="https://cncf.io">CNCF</a> incubation project</h4>
 
 <img class="cncf-logo"
   src="/img/logos/cncf-horizontal-color.png" alt="Cloud Native Computing Foundation logo" />


### PR DESCRIPTION
... to facilitate reuse. This change will also do the right thing if/when grpc.io goes [multilingual](https://gohugo.io/content-management/multilingual/).

Generated site files are not changed by this PR.