### PR TITLE
Dart 2.12+ is required

### DIFF
--- a/content/en/docs/languages/dart/quickstart.md
+++ b/content/en/docs/languages/dart/quickstart.md
@@ -7,7 +7,7 @@ spelling: cSpell:ignore Iprotos
 
 ### Prerequisites
 
-- **[Dart][]** version 2.2 or higher, through the Dart or [Flutter][] SDKs
+- **[Dart][]** version 2.12 or higher, through the Dart or [Flutter][] SDKs
 
   For installation instructions, see [Install Dart][] or [Install Flutter][].
 

--- a/data/officially_supported_lang_os.yaml
+++ b/data/officially_supported_lang_os.yaml
@@ -12,7 +12,7 @@
   compilers: [.NET Core, NET 4.5+]
 - language: Dart
   os: [Windows, Linux, Mac]
-  compilers: [Dart 2.2+]
+  compilers: [Dart 2.12+]
 - language: Go
   os: [Windows, Linux, Mac]
   compilers: [Go 1.13+]


### PR DESCRIPTION
Since [grpc-dart v3.0.0](https://github.com/grpc/grpc-dart/blob/master/CHANGELOG.md#300), Dart 2.12+ is required.

cc @kevmoo