### PR TITLE
Add note that non-posix systems need to specify root CA path for TLS auth

### DIFF
--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -106,9 +106,9 @@ the corresponding options can be set in the `SslCredentialsOptions` parameter
 passed to the factory method.
 
 {{% alert title="Note" color="info" %}}
-  Non-Posix-compliant systems such as Windows need to specify the root
-  certificates in `SslCredentialsOptions` since the defaults are only configured
-  for Posix filesystems.
+  Non-POSIX-compliant systems (such as Windows) need to specify the root
+  certificates in `SslCredentialsOptions`, since the defaults are only
+  configured for POSIX filesystems.
 {{% /alert %}}
 
 #### Using Google token-based authentication

--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -105,6 +105,10 @@ For advanced use cases such as modifying the root CA or using client certs,
 the corresponding options can be set in the `SslCredentialsOptions` parameter
 passed to the factory method.
 
+{{% alert title="Note" color="info" %}}
+  Non-Posix-compliant systems such as Windows need to specify certificate
+  locations since the defaults assume a posix filesystem.
+{{% /alert %}}
 
 #### Using Google token-based authentication
 

--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -106,8 +106,9 @@ the corresponding options can be set in the `SslCredentialsOptions` parameter
 passed to the factory method.
 
 {{% alert title="Note" color="info" %}}
-  Non-Posix-compliant systems such as Windows need to specify certificate
-  locations since the defaults assume a posix filesystem.
+  Non-Posix-compliant systems such as Windows need to specify the root
+  certificates in `SslCredentialsOptions` since the defaults are only configured
+  for Posix filesystems.
 {{% /alert %}}
 
 #### Using Google token-based authentication


### PR DESCRIPTION
Until defaults are updated for other systems, adding this note should help a few folks https://github.com/grpc/grpc/issues/26106

Preview: https://deploy-preview-763--grpc-io.netlify.app/docs/guides/auth/#using-client-side-ssltls