### PR TITLE
Add maintenance-mode banner to C# pages

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,3 +1,7 @@
 /* grpc-docsy full file override: we're not tracking changes to the docsy file of the same name. */
 
 @import "grpc";
+
+.pageinfo {
+  margin: 2rem 0;
+}

--- a/content/en/docs/languages/csharp/_index.md
+++ b/content/en/docs/languages/csharp/_index.md
@@ -14,6 +14,8 @@ content:
     - "[gRPC for .NET](dotnet/)"
     - "[grpc repo]($src_repo_url)"
     - "[Daily builds](daily-builds)"
+cascade:
+  - show_banner: true
 ---
 
 {{% docs/prog-lang-home-content %}}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,16 @@
+{{/* grpc-docsy file override.
+  TODO: move into theme/docsy folder.
+*/ -}}
+{{ if .Params.show_banner -}}
+  {{ $color := "warning" -}}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    <p>
+      <span class="font-weight-bold">IMPORTANT</span>: the Grpc.Core
+      implementation of gRPC for C# is in <span class="font-italic">maintenance
+      mode</span>, and will be replaced by
+      <a href="/docs/languages/csharp/dotnet/">grpc-dotnet</a> in the future.
+      For details, see our
+      <a href="/blog/grpc-csharp-future/">blog post</a>.
+    </p>
+  </div>
+{{ end -}}


### PR DESCRIPTION
- Closes #767
- Followup to  #765, #766

Preview:
- C# landing page (with banner): https://deploy-preview-769--grpc-io.netlify.app/docs/languages/csharp/
- C# quick start (with banner): https://deploy-preview-769--grpc-io.netlify.app/docs/languages/csharp/quickstart/
- Any other docs page not under the C# landing page (w/o banner):
  - https://deploy-preview-769--grpc-io.netlify.app/docs/languages/
  - https://deploy-preview-769--grpc-io.netlify.app/docs/languages/cpp/

### Screenshot

> ![image](https://user-images.githubusercontent.com/4140793/116918109-7f051280-ac1d-11eb-9166-1f3d7966f2cb.png)
