### PR TITLE
Add link to Google calendar

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -36,6 +36,12 @@ other_channels:
       Consult the [`r/grpc`](https://www.reddit.com/r/grpc/) subreddit for
       discussions related to gRPC.
 community_resources:
+ - title: >
+      <a href="https://calendar.google.com/calendar/embed?src=c_c6g7cap1fuvdu8m9a3i83lpd7o%40group.calendar.google.com&ctz=America%2FMexico_City"
+        target="_blank" rel="noopener"><i class="fab
+        fa-calendar"></i>&nbsp;Google Calendar</a>
+    desc: >
+      Add this calendar to stay up to date on community meetusp.
   - title: >
       <a href="https://www.meetup.com/gRPCio/"
         target="_blank" rel="noopener"><i class="fab

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -38,7 +38,7 @@ other_channels:
 community_resources:
   - title: >
       <a href="https://calendar.google.com/calendar/embed?src=c_c6g7cap1fuvdu8m9a3i83lpd7o%40group.calendar.google.com&ctz=America%2FMexico_City"
-        target="_blank" rel="noopener"><i class="fab
+        target="_blank" rel="noopener"><i class="fas
         fa-calendar"></i>&nbsp;Google Calendar</a>
     desc: >
       Add this calendar to stay up to date on community meetups.

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -36,7 +36,7 @@ other_channels:
       Consult the [`r/grpc`](https://www.reddit.com/r/grpc/) subreddit for
       discussions related to gRPC.
 community_resources:
- - title: >
+  - title: >
       <a href="https://calendar.google.com/calendar/embed?src=c_c6g7cap1fuvdu8m9a3i83lpd7o%40group.calendar.google.com&ctz=America%2FMexico_City"
         target="_blank" rel="noopener"><i class="fab
         fa-calendar"></i>&nbsp;Google Calendar</a>

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -41,7 +41,7 @@ community_resources:
         target="_blank" rel="noopener"><i class="fab
         fa-calendar"></i>&nbsp;Google Calendar</a>
     desc: >
-      Add this calendar to stay up to date on community meetusp.
+      Add this calendar to stay up to date on community meetups.
   - title: >
       <a href="https://www.meetup.com/gRPCio/"
         target="_blank" rel="noopener"><i class="fab


### PR DESCRIPTION
### gRPC calendar
Subscribe to the gRPC calendar and stay up to date on the community meetups
[grpc Calendar] https://calendar.google.com/calendar/embed?src=c_c6g7cap1fuvdu8m9a3i83lpd7o%40group.calendar.google.com&ctz=America%2FMexico_City