### PR TITLE
Changed "go install" to "go get" (#808)

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -21,8 +21,8 @@ spelling: cSpell:ignore Fatalf GOPATH
    1. Install the protocol compiler plugins for Go using the following commands:
 
       ```sh
-      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
-      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+      $ go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+      $ go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
       ```
 
    2. Update your `PATH` so that the `protoc` compiler can find the plugins:


### PR DESCRIPTION
Fixing an error with installing prerequisites where using ```go install``` failed with the following information:

```
package google.golang.org/protobuf/cmd/protoc-gen-go@v1.26: can only use path@version syntax with 'go get'
```