### PR TITLE
Drop redundant postcss.config.js file

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    autoprefixer: {}
-  },
-}


### PR DESCRIPTION
The Docsy config file (of the same name) is used. I checked that there is no change in the development or production versions of the generated website files.

/cc @nate-double-u