### PR TITLE
README: no need for nvm use cmd after nvm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The [grpc.io][] site, built using [Hugo][] and hosted on [Netlify][].
   Node Version Manager, to install and manage Node versions:
   ```console
   $ nvm install --lts
-  $ nvm use --lts
   ```
 
 ### 2. Clone this repo _and_ its submodules


### PR DESCRIPTION
Running `nvm install` will perform the equivalent of an `nvm use` if the version is already installed -- otherwise it installs and uses the named version.