### PR TITLE
Replace use of short_title with linkTitle in page front matter

### DIFF
--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Supported languages
-short_title: Languages
+linkTitle: Languages
 weight: 2
 nav_children: section
 notoc: true

--- a/content/en/docs/languages/cpp/alts.md
+++ b/content/en/docs/languages/cpp/alts.md
@@ -1,6 +1,6 @@
 ---
 title: ALTS authentication
-short_title: ALTS
+linkTitle: ALTS
 description: >
   An overview of gRPC authentication in C++ using Application Layer Transport
   Security (ALTS).

--- a/content/en/docs/languages/cpp/api.md
+++ b/content/en/docs/languages/cpp/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/cpp/async.md
+++ b/content/en/docs/languages/cpp/async.md
@@ -1,6 +1,6 @@
 ---
 title: Asynchronous-API tutorial
-short_title: Async-API tutorial
+linkTitle: Async-API tutorial
 weight: 60
 spelling: cSpell:ignore classgrpc Impl's
 ---

--- a/content/en/docs/languages/csharp/api.md
+++ b/content/en/docs/languages/csharp/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/dart/api.md
+++ b/content/en/docs/languages/dart/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/go/alts.md
+++ b/content/en/docs/languages/go/alts.md
@@ -1,6 +1,6 @@
 ---
 title: ALTS authentication
-short_title: ALTS
+linkTitle: ALTS
 description: >
   An overview of gRPC authentication in Go using Application Layer Transport
   Security (ALTS).

--- a/content/en/docs/languages/go/api.md
+++ b/content/en/docs/languages/go/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/go/generated-code.md
+++ b/content/en/docs/languages/go/generated-code.md
@@ -1,6 +1,6 @@
 ---
 title: Generated-code reference
-short_title: Generated code
+linkTitle: Generated code
 weight: 95
 ---
 

--- a/content/en/docs/languages/java/alts.md
+++ b/content/en/docs/languages/java/alts.md
@@ -1,6 +1,6 @@
 ---
 title: ALTS authentication
-short_title: ALTS
+linkTitle: ALTS
 description: >
   An overview of gRPC authentication in Java using Application Layer Transport
   Security (ALTS).

--- a/content/en/docs/languages/java/api.md
+++ b/content/en/docs/languages/java/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/java/generated-code.md
+++ b/content/en/docs/languages/java/generated-code.md
@@ -1,6 +1,6 @@
 ---
 title: Generated-code reference
-short_title: Generated code
+linkTitle: Generated code
 weight: 95
 spelling: cSpell:ignore buildscript classpath grpcexample motd srcs xolstice
 ---

--- a/content/en/docs/languages/kotlin/api.md
+++ b/content/en/docs/languages/kotlin/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/node/api.md
+++ b/content/en/docs/languages/node/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/objective-c/api.md
+++ b/content/en/docs/languages/objective-c/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/php/api.md
+++ b/content/en/docs/languages/php/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/python/alts.md
+++ b/content/en/docs/languages/python/alts.md
@@ -1,6 +1,6 @@
 ---
 title: ALTS authentication
-short_title: ALTS
+linkTitle: ALTS
 description: >
   An overview of gRPC authentication in Python using Application Layer Transport
   Security (ALTS).

--- a/content/en/docs/languages/python/api.md
+++ b/content/en/docs/languages/python/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/languages/python/generated-code.md
+++ b/content/en/docs/languages/python/generated-code.md
@@ -1,6 +1,6 @@
 ---
 title: Generated-code reference
-short_title: Generated code
+linkTitle: Generated code
 weight: 80
 spelling: cSpell:ignore docstrings
 ---

--- a/content/en/docs/languages/ruby/api.md
+++ b/content/en/docs/languages/ruby/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/platforms/_index.md
+++ b/content/en/docs/platforms/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Supported platforms
 description: gRPC is supported across different software and hardware platforms.
-short_title: Platforms
+linkTitle: Platforms
 weight: 2
 nav_children: section
 simple_list: true

--- a/content/en/docs/platforms/android/java/_index.md
+++ b/content/en/docs/platforms/android/java/_index.md
@@ -2,7 +2,7 @@
 title: Android Java
 layout: prog_lang_home
 language: &lang Java
-short_title: *lang
+linkTitle: *lang
 spelling: cSpell:ignore javadoc
 api_path: grpc-java/javadoc
 content:

--- a/content/en/docs/platforms/android/java/api.md
+++ b/content/en/docs/platforms/android/java/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 path: grpc-java/javadoc
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.

--- a/content/en/docs/platforms/android/kotlin/_index.md
+++ b/content/en/docs/platforms/android/kotlin/_index.md
@@ -2,7 +2,7 @@
 title: Kotlin for Android
 layout: prog_lang_home
 language: &lang Kotlin
-short_title: *lang
+linkTitle: *lang
 api_path: https://javadocs.dev/io.grpc/grpc-kotlin-stub/latest
 content:
   - learn_more:

--- a/content/en/docs/platforms/android/kotlin/api.md
+++ b/content/en/docs/platforms/android/kotlin/api.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-short_title: API
+linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
 ---

--- a/content/en/docs/protoc-installation.md
+++ b/content/en/docs/protoc-installation.md
@@ -1,6 +1,6 @@
 ---
 title: Protocol Buffer Compiler Installation
-short_title: Protoc Installation
+linkTitle: Protoc Installation
 description: How to install the protocol buffer compiler.
 protoc-version: 3.15.8
 toc_hide: true

--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core concepts, architecture and lifecycle
-short_title: Core concepts
+linkTitle: Core concepts
 description: >-
   An introduction to key gRPC concepts, with an overview of gRPC architecture
   and RPC life cycle.

--- a/content/en/docs/what-is-grpc/introduction.md
+++ b/content/en/docs/what-is-grpc/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to gRPC
-short_title: Introduction
+linkTitle: Introduction
 description: An introduction to gRPC and protocol buffers.
 weight: 10
 spelling: cSpell:ignore ponycopter


### PR DESCRIPTION
- Contributes to #820
- No change to the generated site files, modulo whitespace and sitemap timestamps:
  ```console
  $ (cd ../grpc.io.g && git diff -b -w --ignore-blank-lines -- . ':(exclude)*.xml') # no output
  ```

---

This screenshot is from the deploy preview at https://deploy-preview-821--grpc-io.netlify.app/docs/languages/cpp/:

> <img src="https://user-images.githubusercontent.com/4140793/129016480-03704917-586e-4ebb-83f4-f1f080fb16fb.png" width=550>

Notice how, in the side-nav on the left, "Languages" and "ALTS", for example, are still abbreviated (as compared to the corresponding full page titles.

---

/cc @nate-double-u