### PR TITLE
Use linkTitle rather than short_title

### DIFF
--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -9,12 +9,9 @@ what the workaround is for
   cursor: pointer;
 }
 
-// Workarounds for external link icons
-a:not(.td-sidebar-link) > .fa-external-link-alt::before {
-  margin-left: 3px;
-}
 a > .fa-external-link-alt::before {
   font-size: 50%;
+  margin-left: 3px;
   opacity: 0.8;
   vertical-align: top;
 }


### PR DESCRIPTION
- Closes #820
- Only whitespace changes to the generated site files (diffed minified version of website, before and after).

Sample page preview: https://deploy-preview-823--grpc-io.netlify.app/docs/languages/cpp/async/

> <img width="1044" alt="Screen Shot 2021-08-11 at 2 36 13 PM" src="https://user-images.githubusercontent.com/4140793/129084447-1d1fdf38-d262-466c-b559-34f5e2e88497.png">

Note that the shortened title is being used in the breadcrumb and the sidenav. Also, external links (as for the API reference), are still present and properly styled with an external link icon
