### PR TITLE
Config: cleanup homepage output format config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,17 +73,16 @@ markup:
     endLevel: 5
     ordered: false
 
-# Configuration required for auto-generating the Netlify _redirects file
+# Netlify _redirects file
+
 mediaTypes:
-  text/netlify:
-    delimiter: ''
+  text/netlify: {}
 
 outputFormats:
   REDIRECTS:
     mediaType: text/netlify
     baseName: _redirects
-  RSS:
-    baseName: feed
+    notAlternative: true
 
 outputs:
   home: [HTML, REDIRECTS, RSS]


### PR DESCRIPTION
- Ensure that the Netlify redirects file isn't used as an homepage `alternate` -- not that this is what is happening currently, but there was the risk (due to a missing config field), see e.g., https://github.com/etcd-io/website/issues/437.
- Use default base name for RSS