### PR TITLE
fix bidirectional streaming PHP example

### DIFF
--- a/content/en/docs/languages/php/basics.md
+++ b/content/en/docs/languages/php/basics.md
@@ -321,7 +321,13 @@ To write messages from the client:
 
 ```php
 foreach ($notes as $n) {
+  $point = new Routeguide\Point();
+  $point->setLatitude($lat = $n[0]);
+  $point->setLongitude($long = $n[1]);
+
   $route_note = new Routeguide\RouteNote();
+  $route_note->setLocation($point);
+  $route_note->setMessage($message = $n[2]);
   $call->write($route_note);
 }
 $call->writesDone();


### PR DESCRIPTION
Related to this issue

Seems that there's a bug in documentation here

foreach ($notes as $n) {
  $route_note = new Routeguide\RouteNote();
  $call->write($route_note);
}
$call->writesDone();`
This code doesn't use $n variable in any way, it just sends an empty RouteNote