### PR TITLE
Don't generate API-placeholder pages

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,15 +7,30 @@ IgnoreURLs:
   - http://bit\.ly/gRPC18survey # survey is closed and DNE
   - https://(www.)?envoyproxy.io # valid link but flakey (https://github.com/envoyproxy/envoyproxy.github.io/issues/193)
 IgnoreInternalURLs:
+  - ../api
+  - /docs/languages/cpp/api/
+  - /docs/languages/csharp/api/
   - /docs/languages/csharp/daily-builds/
+  - /docs/languages/dart/api/
+  - /docs/languages/go/api/
+  - /docs/languages/java/api/
+  - /docs/languages/kotlin/api
+  - /docs/languages/kotlin/api/
+  - /docs/languages/node/api/
+  - /docs/languages/objective-c/api/
+  - /docs/languages/php/api/
   - /docs/languages/php/daily-builds/
+  - /docs/languages/python/api/
   - /docs/languages/python/daily-builds/
+  - /docs/languages/ruby/api/
   - /docs/languages/ruby/daily-builds/
+  - /docs/platforms/android/java/api/
+  - /docs/platforms/android/kotlin/api/
   - /grpc/cpp/classgrpc_1_1_completion_queue.html
   - /grpc/python/_modules/grpc.html#Server
   - /grpc/python/grpc.html?#grpc.StreamStreamMultiCallable
   - /grpc/python/grpc.html?#grpc.StreamUnaryMultiCallable
   - /grpc/python/grpc.html?#grpc.UnaryStreamMultiCallable
   - /grpc/python/grpc.html?#grpc.UnaryUnaryMultiCallable
-  - api
+  - api/
   - daily-builds

--- a/content/en/docs/languages/cpp/api.md
+++ b/content/en/docs/languages/cpp/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/csharp/api.md
+++ b/content/en/docs/languages/csharp/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/csharp/dotnet.md
+++ b/content/en/docs/languages/csharp/dotnet.md
@@ -8,7 +8,7 @@ The following pages cover the C# implementation of gRPC for .NET
 
 - [Introduction to gRPC on .NET Core](https://docs.microsoft.com/aspnet/core/grpc)
 - [Tutorial: Create a gRPC client and server in ASP.NET Core][tutorial]
-- [API reference](api)
+- [API reference](api/)
 
 Several sample applications are available from the [examples][] folder in the
 [grpc-dotnet][] repository.

--- a/content/en/docs/languages/dart/api.md
+++ b/content/en/docs/languages/dart/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/go/api.md
+++ b/content/en/docs/languages/go/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/java/api.md
+++ b/content/en/docs/languages/java/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/kotlin/api.md
+++ b/content/en/docs/languages/kotlin/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/node/_index.md
+++ b/content/en/docs/languages/node/_index.md
@@ -7,4 +7,4 @@ These language-specific pages are available:
 
 - [Quick start](quickstart/)
 - [Basics tutorial](basics/)
-- [API reference](api)
+- [API reference](api/)

--- a/content/en/docs/languages/node/api.md
+++ b/content/en/docs/languages/node/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/objective-c/_index.md
+++ b/content/en/docs/languages/objective-c/_index.md
@@ -9,7 +9,7 @@ These language-specific pages are available:
 - [Quick start](quickstart/)
 - [Basics tutorial](basics/)
 - [OAuth2 tutorial](oauth2/)
-- [API reference](api)
+- [API reference](api/)
 
 Related resources:
 

--- a/content/en/docs/languages/objective-c/api.md
+++ b/content/en/docs/languages/objective-c/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/php/api.md
+++ b/content/en/docs/languages/php/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/python/api.md
+++ b/content/en/docs/languages/python/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -8,5 +8,5 @@ These language-specific pages are available:
 
 - [Quick start](quickstart/)
 - [Basics tutorial](basics/)
-- [API reference](api)
+- [API reference](api/)
 - [Daily builds](daily-builds)

--- a/content/en/docs/languages/ruby/api.md
+++ b/content/en/docs/languages/ruby/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/platforms/android/java/api.md
+++ b/content/en/docs/platforms/android/java/api.md
@@ -4,4 +4,5 @@ linkTitle: API
 path: grpc-java/javadoc
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---

--- a/content/en/docs/platforms/android/kotlin/api.md
+++ b/content/en/docs/platforms/android/kotlin/api.md
@@ -3,4 +3,5 @@ title: API reference
 linkTitle: API
 weight: 90
 # Note: this is a placeholder page. The URL to this page redirects elsewhere.
+_build: { render: link }
 ---


### PR DESCRIPTION
Closes #733

Previews (sample):

- https://deploy-preview-858--grpc-io.netlify.app/docs/languages/go/api/
- https://deploy-preview-858--grpc-io.netlify.app/docs/languages/cpp/api/
- https://deploy-preview-858--grpc-io.netlify.app/docs/languages/java/api/
- https://deploy-preview-858--grpc-io.netlify.app/docs/languages/ruby/api/