### PR TITLE
Update grpc.io-docsy, grpc.io branch

### DIFF
--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -42,14 +42,18 @@ sections site wide to the original site's background svg.
 
 // DOCS
 
-// Extend the sidebar to the end of the visible page.
 .td-toc {
+  padding-top: 1rem;
+}
+
+// Extend the sidebar to the end of the visible page.
+.td-sidebar-toc {
   height: initial;
   padding-top: 4.75rem;
+}
 
-  & ul {
-    margin-bottom: 0;
-  }
+.td-sidebar-nav__section .ul-1 ul {
+  padding-left: 1rem;
 }
 
 // Custom in-page toc. Apply this class as a modifier on top of the Docsy-provided .td-toc


### PR DESCRIPTION
- Closes #819
- Closes #860 by superseding it

As compared to #860, this sticks with the [grpc.io](https://github.com/grpc/grpc.io-docsy/tree/grpc.io) submodule branch of the [grpc.io-docsy](https://github.com/grpc/grpc.io-docsy/tree/grpc.io) repo. That submodule branch is up to date relative to https://github.com/google/docsy/commit/90d3d841b26d1d2988087a7e28a7f18121536ef8, as of 2021-09-19. The last (full) sync with `docsy` was ~6 months ago (2021-03-05)! The look-and-feel is almost the same, except for minor differences in the left sidenav appearance, which I might eventually tweak in a followup PR.

/cc @nate-double-u
