### PR TITLE
Removed abseil installation from C++ doc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ params:
   branch: main
   locale: en_US
   grpc_vers:
-    core: v1.38.0
+    core: v1.40.0
     go: v1.35.0
     java: v1.40.1
   font_awesome_version: 5.12.1

--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -98,15 +98,13 @@ Clone the `grpc` repo and its submodules:
 ```sh
 $ git clone --recurse-submodules -b {{< param grpc_vers.core >}} https://github.com/grpc/grpc
 ```
-#### Build and install gRPC, Protocol Buffers, and Abseil
+#### Build and install gRPC and Protocol Buffers
 
 While not mandatory, gRPC applications usually leverage [Protocol Buffers][pb]
 for service definitions and data serialization, and the example code uses
 [proto3][].
 
-gRPC uses the [Abseil C++ library][abseil], so it needs to be installed as well.
-
-The following commands build and locally install gRPC, Protocol Buffers, and Abseil:
+The following commands build and locally install gRPC and Protocol Buffers:
 
 ```sh
 $ cd grpc
@@ -115,14 +113,6 @@ $ pushd cmake/build
 $ cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
       -DCMAKE_INSTALL_PREFIX=$MY_INSTALL_DIR \
-      ../..
-$ make -j
-$ make install
-$ popd
-$ mkdir -p third_party/abseil-cpp/cmake/build
-$ pushd third_party/abseil-cpp/cmake/build
-$ cmake -DCMAKE_INSTALL_PREFIX=$MY_INSTALL_DIR \
-      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       ../..
 $ make -j
 $ make install
@@ -387,4 +377,3 @@ from the example **build** directory `examples/cpp/helloworld/cmake/build`:
 [proto3]: https://developers.google.com/protocol-buffers/docs/proto3
 [repo]: https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}
 [using-grpc]: https://github.com/grpc/grpc/tree/master/src/cpp#to-start-using-grpc-c
-[abseil]: https://github.com/abseil/abseil-cpp


### PR DESCRIPTION
gRPC can install Abseil when being installed by https://github.com/grpc/grpc/pull/26802 so a separate absel installation step isn't required anymore. This PR effectively undoes https://github.com/grpc/grpc.io/pull/752.