### PR TITLE
Ruby doc fixes

### DIFF
--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -137,9 +137,8 @@ Next we need to generate the gRPC client and server interfaces from our .proto
 service definition. We do this using the protocol buffer compiler `protoc` with
 a special gRPC Ruby plugin.
 
-If you want to run this yourself, make sure you've installed protoc and followed
-the gRPC Ruby plugin [installation
-instructions](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/src/ruby/README.md) first):
+If you want to run this yourself, make sure you have installed
+[gRPC](../quickstart/#grpc) and [protoc](../quickstart/#grpc-tools).
 
 Once that's done, the following command can be used to generate the ruby code.
 


### PR DESCRIPTION
These are two small changes to the Ruby docs in areas that were confusing to me for a little bit. 

Edit: removed this commit:
~~* The Quickstart states that Ruby 2 or higher will work, but the actual `grpc` gem [states](https://github.com/grpc/grpc/tree/master/src/ruby#prerequisites) that Ruby 3.0 is currently not supported due to keyword args.~~
* The Basics section notes that the `grpc` gem is required, but then gives instructions that require the `grpc-tools` gem. In this case, following the instructions in the Quickstart would solve the problem, but mentioning one out of two required libraries is confusing. 