### PR TITLE
Update docker instruction for running the Echo example

### DIFF
--- a/content/en/docs/platforms/web/quickstart.md
+++ b/content/en/docs/platforms/web/quickstart.md
@@ -36,7 +36,7 @@ From the `grpc-web` directory:
  1. Fetch required packages and tools:
 
     ```sh
-    $ docker-compose pull node-server envoy commonjs-client
+    $ docker-compose pull prereqs node-server envoy commonjs-client
     ```
 
     {{% alert title="Note" color="info" %}}


### PR DESCRIPTION
The `prereqs` image is needed as a runtime dependency.

(Also see https://github.com/grpc/grpc-web/pull/1149)