### PR TITLE
Upgrade packages, including hugo-extended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Hugo default output directory
+.hugo_build.lock
 /public
 /resources
 

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,6 +1,7 @@
 DirectoryPath: public
-IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreInternalEmptyHash: true # At least until the following is fixed: https://github.com/gohugoio/hugo/issues/9149
 CheckDoctype: false # Sadly, this is false only because of `google*.html`
 IgnoreURLs:
   - ^https?://localhost

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -243,6 +243,7 @@ c - Component (Aware of its content/context...)
 .grpc-logo {
   max-height: 8rem;
   max-width: 65%;
+  margin-bottom: 1rem;
 }
 
 .used-by-logo {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "submodule:update": "git submodule update --remote --recursive --depth 1"
   },
   "devDependencies": {
-    "autoprefixer": "^10.3.1",
-    "hugo-extended": "0.82.0",
-    "netlify-cli": "^6.6.1",
-    "postcss": "^8.3.6",
-    "postcss-cli": "^8.3.1"
+    "autoprefixer": "^10.4.0",
+    "hugo-extended": "^0.89.2",
+    "netlify-cli": "^6.14.19",
+    "postcss": "^8.3.11",
+    "postcss-cli": "^9.0.2"
   }
 }


### PR DESCRIPTION
- Markdown processor treats the homepage image differently (it avoids unnecessarily wrapping it in a paragraph)
- Some fixes to the syntax highlighter

Related: https://github.com/open-telemetry/opentelemetry.io/pull/890