### PR TITLE
Docs: move menu data into front matter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,37 +87,3 @@ outputFormats:
 
 outputs:
   home: [HTML, REDIRECTS, RSS]
-
-# Site menus
-
-menu:
-  main:
-    - name: Docs
-      url: /docs/
-      identifier: docs
-      weight: 2
-    - name: Overview
-      url: /docs/
-      weight: 1
-      parent: docs
-    - name: What is gRPC?
-      url: /docs/what-is-grpc/
-      weight: 1
-      parent: docs
-    - name: Languages
-      url: /docs/languages/
-      weight: 2
-      parent: docs
-    - name: Platforms
-      url: /docs/platforms/
-      weight: 2
-      parent: docs
-    - name: Guides
-      url: /docs/guides/
-      identifier: guides
-      weight: 4
-      parent: docs
-    - name: FAQ
-      url: /faq/
-      weight: 7
-      parent: docs

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,6 +1,9 @@
 ---
 title: Documentation
+linkTitle: Docs
 no_list: true
+menu:
+  main: {weight: 2}
 ---
 
 Learn about key gRPC concepts, try a quick start, find tutorials and reference


### PR DESCRIPTION
- Closes #895
- As of this final PR of the series, there is no more menu data in the config file

/cc @nate-double-u