### PR TITLE
fix greeter_client/main.go errors

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -161,7 +161,7 @@ Open `greeter_client/main.go` to add the following code to the end of the
 `main()` function body:
 
 ```go
-r, err = c.SayHelloAgain(ctx, &pb.HelloRequest{Name: name})
+r, err = c.SayHelloAgain(ctx, &pb.HelloRequest{Name: *name})
 if err != nil {
         log.Fatalf("could not greet: %v", err)
 }
@@ -185,7 +185,7 @@ from the `examples/helloworld` directory:
     command-line argument:
 
     ```sh
-    $ go run greeter_client/main.go Alice
+    $ go run greeter_client/main.go -name=Alice
     ```
 
     You'll see the following output:


### PR DESCRIPTION
1) greeter_client/main.go:60:47: cannot use helloworld.HelloRequest{...} (type helloworld.HelloRequest) as type *helloworld.HelloRequest in argument to c.SayHelloAgain
greeter_client/main.go:60:48: cannot use name (type *string) as type string in field value

2) cann't assign name in terminal