### PR TITLE
use `insecure.NewCredentials()`

### DIFF
--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -192,7 +192,7 @@ are coming soon.
 Client:
 
 ``` go
-conn, _ := grpc.Dial("localhost:50051", grpc.WithInsecure())
+conn, _ := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
 // error handling omitted
 client := pb.NewGreeterClient(conn)
 // ...


### PR DESCRIPTION
https://pkg.go.dev/google.golang.org/grpc#WithInsecure
> `func WithInsecure() DialOption`
> Deprecated: use insecure.NewCredentials() instead. Will be supported throughout 1.x.
