### PR TITLE
Upgrade Hugo to 0.91.0

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,7 +1,6 @@
 DirectoryPath: public
 IgnoreAltMissing: true
 IgnoreDirectoryMissingTrailingSlash: true
-IgnoreInternalEmptyHash: true # At least until the following is fixed: https://github.com/gohugoio/hugo/issues/9149
 CheckDoctype: false # Sadly, this is false only because of `google*.html`
 IgnoreURLs:
   - ^https?://localhost

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.89.2",
+    "hugo-extended": "0.91.0",
     "netlify-cli": "^6.14.19",
     "postcss": "^8.3.11",
     "postcss-cli": "^9.0.2"


### PR DESCRIPTION
Also dropping `IgnoreInternalEmptyHash` rule now that https://github.com/gohugoio/hugo/issues/9149 has been fixed and deployed.