### PR TITLE
Sync Java versions with grpc-java

### DIFF
--- a/data/officially_supported_lang_os.yaml
+++ b/data/officially_supported_lang_os.yaml
@@ -18,7 +18,7 @@
   compilers: [Go 1.13+]
 - language: Java
   os: [Windows, Linux, Mac]
-  compilers: [JDK 8 recommended (Jelly Bean+ for Android)]
+  compilers: [Java 8+ (KitKat+ for Android)]
 - language: Kotlin
   os: [Windows, Linux, Mac]
   compilers: [Kotlin 1.3+]


### PR DESCRIPTION
Java 7 support was dropped with 5635c6cb4 (Jan 27 2022) and Jelly Bean was dropped
with 2e87cd6a (Oct 20 2021)