### PR TITLE
Fixes #918 - Ruby Multithreaded Client Streaming Documentation

### DIFF
--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -334,12 +334,14 @@ resps.each do |r|
 end
 ```
 
-Streaming RPCs block until the server closes the connection. For non-blocking
-operation, multiple threads must be utilizes as well as the `return_op: true`
-flag. The flag changes the response of the call from a blocking enumerable to a
-`Operation` which gives some control over the connection. The blocking enumerable
-may be processed in a separate thread. This is useful for connecting to persistent
-RPC sessions that keeps the connection open indefinitely.
+Non-blocking usage of the RPC stream can be achieved with multiple threads and 
+the `return_op: true` flag. When passing the `return_op: true` flag, the 
+execution of the RPC is deferred and an `Operation` object is returned. The RPC 
+can then be executed in another thread by calling the operation `execute` 
+function. The main thread can utilize contextual methods and getters such as 
+`status`, `cancelled?`, and `cancel` to manage the connection. This can be 
+useful for managing persistent RPC sessions that may keep the connection open 
+indefinitely.
 
 ```ruby
 op = stub.list_features(LIST_FEATURES_RECT, return_op: true)
@@ -355,7 +357,7 @@ end
 # controls for the operation
 op.status
 op.cancelled?
-op.cancel # terminates connection and raises GRPC::Cancelled in the thread.
+op.cancel # terminates the connection and raises GRPC::Cancelled in the blocking thread if successful.
 ```
 
 

--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -358,7 +358,7 @@ end
 # controls for the operation
 op.status
 op.cancelled?
-op.cancel # terminates the connection and raises GRPC::Cancelled in the blocking thread if successful.
+op.cancel # attempts to cancel the RPC with a GRPC::Cancelled status; there's a fundamental race condition where cancelling the RPC can race against RPC termination for a different reason - invoking `cancel` doesn't necessarily guarantee a `Cancelled` status
 ```
 
 

--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -339,9 +339,10 @@ the `return_op: true` flag. When passing the `return_op: true` flag, the
 execution of the RPC is deferred and an `Operation` object is returned. The RPC 
 can then be executed in another thread by calling the operation `execute` 
 function. The main thread can utilize contextual methods and getters such as 
-`status`, `cancelled?`, and `cancel` to manage the connection. This can be 
-useful for managing persistent RPC sessions that may keep the connection open 
-indefinitely.
+`status`, `cancelled?`, and `cancel` to manage the RPC. This can be useful for 
+persistent or long running RPC sessions that would block the main thread for an
+unacceptable period of time.
+
 
 ```ruby
 op = stub.list_features(LIST_FEATURES_RECT, return_op: true)


### PR DESCRIPTION
Please see #918. Fixes missing documentation for achieving non-blocking client streaming.