### PR TITLE
Fixing the port number for local site development

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You'll find the generated site files in the `public` folder.
 ## Serve the site locally
 
 
-To locally serve the site at [localhost:8888][], run the following command:
+To locally serve the site at [localhost:1313][], run the following command:
 
 ```console
 $ npm run serve


### PR DESCRIPTION
Please refer to #945. Fixes the README documentation of the wrong port number when launching local development environment for grpc.io.