### PR TITLE
Examples: add --shallow-submodules to clone command

### DIFF
--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -96,7 +96,7 @@ Install the basic tools required to build gRPC:
 Clone the `grpc` repo and its submodules:
 
 ```sh
-$ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 ```
 #### Build and install gRPC and Protocol Buffers
 

--- a/content/en/docs/languages/csharp/basics.md
+++ b/content/en/docs/languages/csharp/basics.md
@@ -31,7 +31,7 @@ download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 ```
 

--- a/content/en/docs/languages/csharp/quickstart.md
+++ b/content/en/docs/languages/csharp/quickstart.md
@@ -30,7 +30,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 ```
 

--- a/content/en/docs/languages/dart/basics.md
+++ b/content/en/docs/languages/dart/basics.md
@@ -33,7 +33,7 @@ To download the example, clone the `grpc-dart` repository by running the followi
 command:
 
 ```sh
-$ git clone --depth 1 https://github.com/grpc/grpc-dart.git
+$ git clone --depth 1 https://github.com/grpc/grpc-dart
 ```
 
 Then change your current directory to `grpc-dart/example/route_guide`:

--- a/content/en/docs/languages/java/basics.md
+++ b/content/en/docs/languages/java/basics.md
@@ -35,7 +35,7 @@ To download the example, clone the latest release in `grpc-java` repository by
 running the following command:
 
 ```sh
-$ git clone -b {{< param grpc_vers.java >}} --depth 1 https://github.com/grpc/grpc-java.git
+$ git clone -b {{< param grpc_vers.java >}} --depth 1 https://github.com/grpc/grpc-java
 ```
 
 Then change your current directory to `grpc-java/examples`:

--- a/content/en/docs/languages/node/basics.md
+++ b/content/en/docs/languages/node/basics.md
@@ -45,7 +45,7 @@ To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 ```
 

--- a/content/en/docs/languages/node/quickstart.md
+++ b/content/en/docs/languages/node/quickstart.md
@@ -18,7 +18,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 # Navigate to the node example
 $ cd grpc/examples/node
 # Install the example's dependencies

--- a/content/en/docs/languages/objective-c/basics.md
+++ b/content/en/docs/languages/objective-c/basics.md
@@ -34,7 +34,7 @@ To download the example, clone the `grpc` repository by running the following
 commands:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```

--- a/content/en/docs/languages/objective-c/oauth2.md
+++ b/content/en/docs/languages/objective-c/oauth2.md
@@ -27,7 +27,7 @@ The example code for our tutorial is in
 download the example, clone this repository by running the following commands:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```

--- a/content/en/docs/languages/objective-c/quickstart.md
+++ b/content/en/docs/languages/objective-c/quickstart.md
@@ -50,7 +50,7 @@ Quickstart. Copy the source code from GitHub
 [repository](https://github.com/grpc/grpc):
 
 ```sh
-$ git clone --recursive -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc.git
+$ git clone --recursive -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 ```
 
 ### Install gRPC plugins and libraries

--- a/content/en/docs/languages/php/basics.md
+++ b/content/en/docs/languages/php/basics.md
@@ -33,7 +33,7 @@ To download the example, clone the `grpc` repository and its submodules by runni
 command:
 
 ```sh
-$ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 ```
 
 You need the `grpc-php-plugin` to help you compile `.proto` files. Build it from source as follows:

--- a/content/en/docs/languages/php/quickstart.md
+++ b/content/en/docs/languages/php/quickstart.md
@@ -23,7 +23,7 @@ The example code is part of the [grpc][] repo.
  1. Clone the [grpc][] repo and its submodules:
 
     ```sh
-    $ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+    $ git clone --recurse-submodules -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
     ```
 
  2. Change to the quick start example directory:

--- a/content/en/docs/languages/python/basics.md
+++ b/content/en/docs/languages/python/basics.md
@@ -33,7 +33,7 @@ To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 ```
 
 Then change your current directory to `examples/python/route_guide` in the repository:

--- a/content/en/docs/languages/python/quickstart.md
+++ b/content/en/docs/languages/python/quickstart.md
@@ -65,7 +65,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 # Navigate to the "hello, world" Python example:
 $ cd grpc/examples/python/helloworld
 ```

--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -32,7 +32,7 @@ To download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 $ cd grpc
 ```
 

--- a/content/en/docs/languages/ruby/quickstart.md
+++ b/content/en/docs/languages/ruby/quickstart.md
@@ -41,7 +41,7 @@ and other tutorials):
 
 ```sh
 # Clone the repository to get the example code:
-$ git clone -b {{< param grpc_vers.core >}} --depth 1 https://github.com/grpc/grpc
+$ git clone -b {{< param grpc_vers.core >}} --depth 1 --shallow-submodules https://github.com/grpc/grpc
 # Navigate to the "hello, world" Ruby example:
 $ cd grpc/examples/ruby
 ```


### PR DESCRIPTION
- Closes #955

Preview, e.g.:

- https://deploy-preview-956--grpc-io.netlify.app/docs/languages/cpp/quickstart/#clone-the-grpc-repo
- https://deploy-preview-956--grpc-io.netlify.app/docs/languages/python/basics/#example-code-and-setup