### PR TITLE
Update Go quickstart to suggest using latest version

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -21,6 +21,12 @@ spelling: cSpell:ignore Fatalf GOPATH
    1. Install the protocol compiler plugins for Go using the following commands:
 
       ```sh
+      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      ```
+      or, you can fetch a particular version of the plugin using:
+      
+      ```sh
       $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
       $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
       ```

--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -20,16 +20,12 @@ spelling: cSpell:ignore Fatalf GOPATH
 
    1. Install the protocol compiler plugins for Go using the following commands:
 
-      ```sh
-      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-      ```
-      or, you can fetch a particular version of the plugin using:
       
       ```sh
-      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
-      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
       ```
+      
 
    2. Update your `PATH` so that the `protoc` compiler can find the plugins:
 

--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -20,12 +20,10 @@ spelling: cSpell:ignore Fatalf GOPATH
 
    1. Install the protocol compiler plugins for Go using the following commands:
 
-      
       ```sh
       $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
       $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
       ```
-      
 
    2. Update your `PATH` so that the `protoc` compiler can find the plugins:
 


### PR DESCRIPTION
Updated the Go quickstart guide to suggest installation of latest version of `protoc-gen-go` and `protoc-gen-go-grpc`. Also added the versioned info as an option.

---

Edit(@chalin)

Preview: https://deploy-preview-964--grpc-io.netlify.app/docs/languages/go/quickstart/