### PR TITLE
Ruby language-home: use new layout & link to examples

### DIFF
--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Ruby
-api_path: grpc/LANG/namespace_grpc
+api_path: https://rubydoc.info/gems/grpc
 prog_lang_home: true
 src_repo: https://github.com/grpc/grpc
 content:

--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -1,12 +1,16 @@
 ---
 title: Ruby
-api_path: https://rubydoc.info/gems/grpc
-no_list: true
+api_path: grpc/LANG/namespace_grpc
+prog_lang_home: true
+src_repo: https://github.com/grpc/grpc
+content:
+  - learn_more:
+    - "[Examples]($src_repo_url/tree/master/examples/ruby)"
+  - reference:
+    - "[API](api/)"
+  - other:
+    - "[grpc repo]($src_repo_url)"
+    - "[Daily builds](daily-builds)"
 ---
 
-These language-specific pages are available:
-
-- [Quick start](quickstart/)
-- [Basics tutorial](basics/)
-- [API reference](api/)
-- [Daily builds](daily-builds)
+{{% docs/prog-lang-home-content %}}


### PR DESCRIPTION
I found Ruby landing-page's layout is not updated.
Contributes to #481, #345

Preview: https://deploy-preview-970--grpc-io.netlify.app/docs/languages/ruby/

Screenshot:

<img width="928" alt="Screen Shot 2022-05-02 at 16 45 40" src="https://user-images.githubusercontent.com/8979468/166201877-8d24dca2-0424-41f4-97e2-5e556a227254.png">

