### PR TITLE
Update quickstart.md

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -129,8 +129,8 @@ Before you can use the new service method, you need to recompile the updated
 While still in the `examples/helloworld` directory, run the following command:
 
 ```sh
-$ protoc --go_out=. --go_opt=paths=source_relative \
-    --go-grpc_out=. --go-grpc_opt=paths=source_relative \
+$ protoc --go_out=. \
+    --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false \
     helloworld/helloworld.proto
 ```
 


### PR DESCRIPTION
I got stucked at running the protoc command inside the current documentation.
I changed the command and it now works for me.

Also - what works best for me, was to change to `option go_package` from
`option go_package = "google.golang.org/grpc/examples/helloworld/helloworld";` 
to
`option go_package = "/helloworld";`

Since this is not mentioned inside the current documentation, I still left it outside - just wanted to mention