### PR TITLE
Fix the date of the Update note

### DIFF
--- a/content/en/blog/grpc-csharp-future.md
+++ b/content/en/blog/grpc-csharp-future.md
@@ -7,7 +7,7 @@ author:
   link: https://github.com/jtattermusch
 ---
 
-**Update 2021-05-03: The maintenance period for `Grpc.Core` has been extended until May 2023. See [announcement][updates] for more info on the future of `Grpc.Core`.**
+**Update 2022-05-03: The maintenance period for `Grpc.Core` has been extended until May 2023. See [announcement][updates] for more info on the future of `Grpc.Core`.**
 
 **TL;DR** grpc-dotnet (the
 [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client/) and


### PR DESCRIPTION
Corrected the year to 2022-05-03. Nuance is that the google group announcement is published on 2022-05-03 and this blog was updated 2022-05-05.  However, it is not 2021.