### PR TITLE
Java/basics: fix heading level

### DIFF
--- a/content/en/docs/languages/java/basics.md
+++ b/content/en/docs/languages/java/basics.md
@@ -195,7 +195,7 @@ private static class RouteGuideService extends RouteGuideGrpc.RouteGuideImplBase
 }
 ```
 
-#### Simple RPC
+##### Simple RPC
 
 `RouteGuideService` implements all our service methods. Let's
 look at the simplest method first, `GetFeature()`, which just gets a `Point` from


### PR DESCRIPTION
The "Simple RPC" heading should be at the next level of the
"Implementing RouteGuide", just like other types of service methods,
such as "Server-side streaming RPC".