### PR TITLE
Simplify the wording - remove the word "opaque"

### DIFF
--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -197,7 +197,7 @@ terminates the RPC immediately so that no further work is done.
 Metadata is information about a particular RPC call (such as [authentication
 details](/docs/guides/auth/)) in the form of a list of key-value pairs, where the
 keys are strings and the values are typically strings, but can be binary data.
-Metadata is opaque to gRPC itself - it lets the client provide information
+Metadata is not visible to gRPC itself - it lets the client provide information
 associated with the call to the server and vice versa.
 
 Access to metadata is language dependent.


### PR DESCRIPTION
I had to look up what opaque was and the explanations were not very clear.
To simplify and make readability more obvious I changed "opaque" to "not visible".
Please verify it makes sense.