### PR TITLE
Clarify metadata requirements which helps users unfamilier with gRPC

### DIFF
--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -198,10 +198,9 @@ Metadata is information about a particular RPC call (such as [authentication
 details](/docs/guides/auth/)) in the form of a list of key-value pairs, where the
 keys are strings and the values are typically strings, but can be binary data.
 
-Keys must consist of lowercase letters, digits, and special characters `-`, `_`,
+Keys are case insensitive and consists of ASCII letters, digits, and special characters `-`, `_`,
 `.` and must not be start with `grpc-` (which are reserved for gRPC itself).
-If the value is binary data, the key must end with suffix `-bin` and otherwise 
-keys must not end with `-bin`.
+Binary-valued keys end in `-bin` while ASCII-valued keys do not.
 
 Metadata is opaque to gRPC itself - it lets the client provide information
 associated with the call to the server and vice versa.

--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -197,6 +197,12 @@ terminates the RPC immediately so that no further work is done.
 Metadata is information about a particular RPC call (such as [authentication
 details](/docs/guides/auth/)) in the form of a list of key-value pairs, where the
 keys are strings and the values are typically strings, but can be binary data.
+
+Keys must consist of lowercase letters, digits, and special characters `-`, `_`,
+`.` and must not be start with `grpc-` (which are reserved for gRPC itself).
+If the value is binary data, the key must end with suffix `-bin` and otherwise 
+keys must not end with `-bin`.
+
 Metadata is opaque to gRPC itself - it lets the client provide information
 associated with the call to the server and vice versa.
 


### PR DESCRIPTION
gRPC metadata allows only subsets of characters but it is not clear in document.
As far as I know full specification of gRPC metadata is written in [here](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) but for core-concept document, I tried to pickup the points which may confuse user new to gRPC.

Related issue: https://github.com/grpc/grpc/issues/9863

Some language libraries accept upper case letters as the key and they convert it to lowercase automatically, but this behavior written on document as below, so users may not be confused.

Go: https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#creating-a-new-metadata

> Note: all the keys will be automatically converted to lowercase, so "key1" and "kEy1" will be the same key and their values will be merged into the same list. This happens for both New and Pairs.

Java: https://grpc.github.io/grpc-java/javadoc/io/grpc/Metadata.Key.html

> uppercase letters: A-Z (normalized to lower) 

Note:
I wondered document should mention about binary header suffix "-bin", and reserved (and used) header prefix "grpc-", but I think it's safe to mention to prevent the unintentional conflict of name.

