### PR TITLE
Analytics: configure GA4 ID as main id

### DIFF
--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,11 +1,13 @@
+{{ $ga4_id := "G-8H17ZWYV40" -}}
 {{ $cnfc_id := "UA-163836834-2" -}}
 {{ $google_id := "UA-60127042-1" -}}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ $cnfc_id }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ $ga4_id }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
+  gtag('config', '{{ $ga4_id }}');
   gtag('config', '{{ $cnfc_id }}');
   gtag('config', '{{ $google_id }}');
 </script>


### PR DESCRIPTION
- Contributes to #1001
- Note that we won't be able to see the effect of this PR until it is deployed to the production server.