### PR TITLE
Upgrade to Hugo 0.95.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,15 @@
     "serve:hugo": "npm run _serve:hugo",
     "serve": "npm run _serve",
     "test": "npm run check-links",
+    "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
+    "update:pkg:hugo+": "npm install --save-dev autoprefixer@latest postcss@latest postcss-cli@latest",
     "update:submodule": "set -x && git submodule update --remote --recursive ${DEPTH:- --depth 1}"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.2",
-    "hugo-extended": "0.93.2",
+    "autoprefixer": "^10.4.8",
+    "hugo-extended": "0.95.0",
     "netlify-cli": "^9.12.3",
-    "postcss": "^8.4.7",
-    "postcss-cli": "^9.1.0"
+    "postcss": "^8.4.16",
+    "postcss-cli": "^10.0.0"
   }
 }


### PR DESCRIPTION
Here's the only signficant diff:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.9")
```
```diff
diff --git a/blog/page/1/index.html b/blog/page/1/index.html
index 5a0634a8..a3be1497 100644
--- a/blog/page/1/index.html
+++ b/blog/page/1/index.html
@@ -1 +1,10 @@
-<!DOCTYPE html><html><head><title>https://grpc.io/blog/</title><link rel="canonical" href="https://grpc.io/blog/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=https://grpc.io/blog/" /></head></html>
\ No newline at end of file
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <title>https://grpc.io/blog/</title>
+    <link rel="canonical" href="https://grpc.io/blog/">
+    <meta name="robots" content="noindex">
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://grpc.io/blog/">
+  </head>
+</html>
```