### PR TITLE
Update Hugo to 0.99.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.8",
-    "hugo-extended": "0.95.0",
+    "hugo-extended": "0.99.1",
     "netlify-cli": "^9.12.3",
     "postcss": "^8.4.16",
     "postcss-cli": "^10.0.0"


### PR DESCRIPTION
No change to the generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.9")
$
```