### PR TITLE
Upgrade grpc.io-docsy to match docsy 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "_build": "hugo --cleanDestinationDir -e dev -DFE",
     "_check-links": "make check-links",
     "_get:no": "echo SKIPPING get operation",
-    "_get:submodule": "set -x && git submodule update --init --recursive ${DEPTH:- --depth 1}",
+    "_get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
     "_prebuild": "npm run get:submodule",
+    "_prepare:docsy": "cd themes/docsy && npm install",
     "_serve:hugo": "hugo serve -DFE --minify",
     "_serve": "netlify dev -c \"npm run _serve:hugo\"",
     "build:preview": "set -x && npm run _build -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
@@ -22,6 +23,7 @@
     "precheck-links:all": "npm run build",
     "precheck-links": "npm run build",
     "preinstall": "npm run get:submodule",
+    "prepare": "npm run get:submodule && npm run _prepare:docsy",
     "preserve:hugo": "npm run _prebuild",
     "preserve": "npm run _prebuild",
     "serve:hugo": "npm run _serve:hugo",
@@ -29,7 +31,7 @@
     "test": "npm run check-links",
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
     "update:pkg:hugo+": "npm install --save-dev autoprefixer@latest postcss@latest postcss-cli@latest",
-    "update:submodule": "set -x && git submodule update --remote --recursive ${DEPTH:- --depth 1}"
+    "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.8",


### PR DESCRIPTION
- With this PR, there are no more recursive git submodules.
- This PR allows us to subsequently upgrade Hugo beyond 0.99.1
- To view the diff between the `grpc.io` branch and the main Docsy branch use the following URL (not bad, only 10 files differ): https://github.com/google/docsy/compare/v0.4.0...grpc:grpc.io-docsy:grpc.io-upto-doccsy-0.4.0
- Generated site file diffs are mainly due to `aria-disabled` being added to the last of the breadcrumbs:
  ```console
  $ (cd public && git diff -bw --ignore-blank-lines -I "<html (lang|itemscope)" -I "fab fa-github|fas fa-tasks" -I "td-(docs|section)-nav" -- . ':(exclude)*.map' ':(exclude)*.css' ':(exclude)*.js') | grep  -E '^- |^\+ ' | grep -v '<a href="https://grpc.io/docs/' | grep -v aria-diabled
  $
  $ (cd public && git diff -bw --ignore-blank-lines -I "<html (lang|itemscope)" -I "fab fa-github|fas fa-tasks" -I "td-(docs|section)-nav" -- . ':(exclude)*.map' ':(exclude)*.css' ':(exclude)*.js') | grep -E '^- |^\+ '
  -    <a href="https://grpc.io/docs/guides/auth/">Authentication</a>
  +    <a href="https://grpc.io/docs/guides/auth/" aria-disabled="true" class="btn-link disabled">Authentication</a>
  -    <a href="https://grpc.io/docs/guides/benchmarking/">Benchmarking</a>
  +    <a href="https://grpc.io/docs/guides/benchmarking/" aria-disabled="true" class="btn-link disabled">Benchmarking</a>
  -    <a href="https://grpc.io/docs/guides/error/">Error handling</a>
  +    <a href="https://grpc.io/docs/guides/error/" aria-disabled="true" class="btn-link disabled">Error handling</a>
  -    <a href="https://grpc.io/docs/guides/">Guides</a>
  +    <a href="https://grpc.io/docs/guides/" aria-disabled="true" class="btn-link disabled">Guides</a>
  -    <a href="https://grpc.io/docs/guides/performance/">Performance Best Practices</a>
  +    <a href="https://grpc.io/docs/guides/performance/" aria-disabled="true" class="btn-link disabled">Performance Best Practices</a>
  ...
  ```

Other changes:

- Page-meta link **Create documentation issue** now uses the same icon as **Create project issue**
- Slight adjustment in font sizes due to https://github.com/twbs/bootstrap/pull/23816. For example, compare the page footer text before and after. I've ensured that, e.g., the footer design still works on mobile.

/cc @nate-double-u