### PR TITLE
Ensure og:title is set -- workaround

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,4 +1,5 @@
 ---
+title: gRPC
 features:
   - title: Simple service definition
     description: Define your service using Protocol Buffers, a powerful binary serialization toolset and language


### PR DESCRIPTION
- Submitting this patch so that the duplicate meta elements are at least consistent.
- Contributes to #744