### PR TITLE
Update grpc_vers.core to v1.48.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ params:
   branch: main
   locale: en_US
   grpc_vers:
-    core: v1.46.3
+    core: v1.48.0
     go: v1.48.0
     java: v1.49.0
   font_awesome_version: 5.12.1


### PR DESCRIPTION
I couldn't built grpc v1.46.3 (see https://stackoverflow.com/questions/72495450/protobuf-permission-issue-when-install-grpc/). As version 1.48.0 built correctly and is the latest version, this version should be used in "C++ Quick Start" page (https://grpc.io/docs/languages/cpp/quickstart/)