### PR TITLE
Improved 'make' commandline option

### DIFF
--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -114,7 +114,7 @@ $ cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
       -DCMAKE_INSTALL_PREFIX=$MY_INSTALL_DIR \
       ../..
-$ make -j
+$ make -j $(nproc)
 $ make install
 $ popd
 ```


### PR DESCRIPTION
The former call 'make -j' keeps spawning an unlimited amount of threads. This reproducibly leads to memory exhaustion on my system (Manjaro Linux with 32GB RAM) and a subsequent crash. 'make -j $(nproc)' only spawns a limited number of compilations threads adjusted to the available cores.