### PR TITLE
Redirect www to apex domain using Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@ command = "npm run build:preview"
 
 [context.production]
 command = "npm run build:production"
+
+[[redirects]]
+from = "https://www.grpc.io/*"
+to = "https://grpc.io/:splat"
+force = true


### PR DESCRIPTION
This is an attempt at resolving

- #1012

without any further Netlify configuration changes (such as switching to Netlify's support for HTTPS, which would be a more significant change).

/cc @ejona86 @thisisnotapril @nate-double-u