### PR TITLE
Fix link to "Officially supported languages and platforms"

### DIFF
--- a/content/en/docs/what-is-grpc/faq.md
+++ b/content/en/docs/what-is-grpc/faq.md
@@ -31,9 +31,7 @@ Google has been using a lot of the underlying technologies and concepts in gRPC 
 
 ### Which programming languages are supported?
 
-See [Officially supported languages and platforms][].
-
-[Officially supported languages and platforms]: /about/#officially-supported-languages-and-platforms
+See [Officially supported languages and platforms](https://grpc.io/docs/languages/).
 
 ### How do I get started using gRPC?
 

--- a/content/en/docs/what-is-grpc/faq.md
+++ b/content/en/docs/what-is-grpc/faq.md
@@ -31,7 +31,7 @@ Google has been using a lot of the underlying technologies and concepts in gRPC 
 
 ### Which programming languages are supported?
 
-See [Officially supported languages and platforms](https://grpc.io/docs/languages/).
+For officially supported languages and platforms, see [Official support](/docs/#official-support).
 
 ### How do I get started using gRPC?
 


### PR DESCRIPTION
I found some link rot while reading Officially Supported Languages