### PR TITLE
Update Java version to 1.51.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ params:
   grpc_vers:
     core: v1.50.0
     go: v1.50.0
-    java: v1.51.0
+    java: v1.51.1
   font_awesome_version: 5.12.1
   gcs_engine_id: 788f3b1ec3a111a2f
   ui:


### PR DESCRIPTION
1.51.1 has been released and shows up at https://search.maven.org/search?q=g:io.grpc