### PR TITLE
Grammar fixes for core-concepts.md

### DIFF
--- a/content/en/docs/what-is-grpc/core-concepts.md
+++ b/content/en/docs/what-is-grpc/core-concepts.md
@@ -198,8 +198,8 @@ Metadata is information about a particular RPC call (such as [authentication
 details](/docs/guides/auth/)) in the form of a list of key-value pairs, where the
 keys are strings and the values are typically strings, but can be binary data.
 
-Keys are case insensitive and consists of ASCII letters, digits, and special characters `-`, `_`,
-`.` and must not be start with `grpc-` (which are reserved for gRPC itself).
+Keys are case insensitive and consist of ASCII letters, digits, and special characters `-`, `_`,
+`.` and must not start with `grpc-` (which is reserved for gRPC itself).
 Binary-valued keys end in `-bin` while ASCII-valued keys do not.
 
 Metadata is opaque to gRPC itself - it lets the client provide information


### PR DESCRIPTION
Small bundle of grammar/typo fixes for the 'Metadata' section in core-concepts.md