### PR TITLE
Update to grpc-go v1.52.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.50.0
-    go: v1.50.0
+    go: v1.52.0
     java: v1.51.1
   font_awesome_version: 5.12.1
   gcs_engine_id: 788f3b1ec3a111a2f


### PR DESCRIPTION
Released today: https://github.com/grpc/grpc-go/releases/tag/v1.52.0