### PR TITLE
Update java version to 1.52.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ params:
   grpc_vers:
     core: v1.50.0
     go: v1.50.0
-    java: v1.51.1
+    java: v1.52.0
   font_awesome_version: 5.12.1
   gcs_engine_id: 788f3b1ec3a111a2f
   ui:


### PR DESCRIPTION
1.52.0 has been released and shows up at https://mvnrepository.com/search?q=g%3Aio.grpc