### PR TITLE
Update Go to use 1.52.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.50.0
-    go: v1.52.0
+    go: v1.52.3
     java: v1.52.0
   font_awesome_version: 5.12.1
   gcs_engine_id: 788f3b1ec3a111a2f


### PR DESCRIPTION
Hi, We need to update version to a patch release. Please check our release notes for more [details](https://github.com/grpc/grpc-go/releases)