### PR TITLE
Update Protocol Buffers documentation URL

### DIFF
--- a/content/en/docs/languages/cpp/basics.md
+++ b/content/en/docs/languages/cpp/basics.md
@@ -14,13 +14,13 @@ By walking through this example you'll learn how to:
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
 with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
 buffers language: you can find out more in
 the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and [C++
+guide](https://protobuf.dev/programming-guides/proto3) and [C++
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated).
+guide](https://protobuf.dev/reference/cpp/cpp-generated).
 
 ### Why use gRPC?
 
@@ -50,7 +50,7 @@ Get the example code and build gRPC:
 
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
-[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+[protocol buffers](https://protobuf.dev/overview).
 You can see the complete .proto file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -374,6 +374,6 @@ from the example **build** directory `examples/cpp/helloworld/cmake/build`:
 [github.com/google/protobuf/releases]: https://github.com/google/protobuf/releases
 [Installing CMake]: https://cmake.org/install
 [pb]: https://developers.google.com/protocol-buffers
-[proto3]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3]: https://protobuf.dev/programming-guides/proto3
 [repo]: https://github.com/grpc/grpc/tree/{{< param grpc_vers.core >}}
 [using-grpc]: https://github.com/grpc/grpc/tree/master/src/cpp#to-start-using-grpc-c

--- a/content/en/docs/languages/dart/basics.md
+++ b/content/en/docs/languages/dart/basics.md
@@ -15,11 +15,11 @@ By walking through this example you'll learn how to:
 - Use the Dart gRPC API to write a simple client and server for your service.
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
-with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). Note that the
+with [protocol buffers](https://protobuf.dev/overview). Note that the
 example in this tutorial uses the proto3 version of the protocol buffers
 language: you can find out more in the
 [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3).
+guide](https://protobuf.dev/programming-guides/proto3).
 
 ### Why use gRPC?
 
@@ -49,7 +49,7 @@ interface code -- if you haven't, see [Quick start][] for setup instructions.
 
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
-[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the
+[protocol buffers](https://protobuf.dev/overview). You can see the
 complete .proto file in
 [`example/route_guide/protos/route_guide.proto`](https://github.com/grpc/grpc-dart/blob/master/example/route_guide/protos/route_guide.proto).
 

--- a/content/en/docs/languages/dart/quickstart.md
+++ b/content/en/docs/languages/dart/quickstart.md
@@ -239,5 +239,5 @@ issue][issue] over the [grpc-dart][] repo.
 [Install Flutter]: https://flutter.dev/docs/get-started/install
 [issue]: https://github.com/grpc/grpc-dart/issues/new
 [pb]: https://developers.google.com/protocol-buffers
-[proto3]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3]: https://protobuf.dev/programming-guides/proto3
 [pbc-install]: /docs/protoc-installation/

--- a/content/en/docs/languages/go/basics.md
+++ b/content/en/docs/languages/go/basics.md
@@ -15,12 +15,12 @@ By walking through this example you'll learn how to:
 - Use the Go gRPC API to write a simple client and server for your service.
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar with
-[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+[protocol buffers](https://protobuf.dev/overview).
 Note that the example in this tutorial uses the proto3 version of the protocol
 buffers language: you can find out more in the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and the
+guide](https://protobuf.dev/programming-guides/proto3) and the
 [Go generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/go-generated).
+guide](https://protobuf.dev/reference/go/go-generated).
 
 ### Why use gRPC?
 
@@ -53,7 +53,7 @@ The example code is part of the [grpc-go][] repo.
 
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
-[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+[protocol buffers](https://protobuf.dev/overview).
 For the complete `.proto` file, see
 [routeguide/route_guide.proto](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/routeguide/route_guide.proto).
 

--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -208,6 +208,6 @@ from the `examples/helloworld` directory:
 [Go]: https://golang.org
 [grpc-go]: https://github.com/grpc/grpc-go
 [pb]: https://developers.google.com/protocol-buffers
-[proto3]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3]: https://protobuf.dev/programming-guides/proto3
 [pbc-install]: /docs/protoc-installation/
 [releases of Go]: https://golang.org/doc/devel/release.html

--- a/content/en/docs/languages/java/basics.md
+++ b/content/en/docs/languages/java/basics.md
@@ -15,13 +15,13 @@ By walking through this example you'll learn how to:
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
 with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the
 [proto3](https://github.com/google/protobuf/releases) version of the protocol
 buffers language: you can find out more in the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and [Java
+guide](https://protobuf.dev/programming-guides/proto3) and [Java
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/java-generated).
+guide](https://protobuf.dev/reference/java/java-generated).
 
 ### Why use gRPC?
 
@@ -49,7 +49,7 @@ $ cd grpc-java/examples
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
 [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file in
 [grpc-java/examples/src/main/proto/route_guide.proto](https://github.com/grpc/grpc-java/blob/master/examples/src/main/proto/route_guide.proto).
 

--- a/content/en/docs/languages/kotlin/basics.md
+++ b/content/en/docs/languages/kotlin/basics.md
@@ -535,7 +535,7 @@ Finished RouteChat
 [Flow]: https://kotlinlang.org/docs/reference/coroutines/flow.html#flows
 [grpc-kotlin]: https://github.com/grpc/grpc-kotlin
 [Introduction to gRPC]: /docs/what-is-grpc/introduction/
-[proto3]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3]: https://protobuf.dev/programming-guides/proto3
 [Prerequisites]: ../quickstart/#prerequisites
 [protos-src]: https://github.com/grpc/grpc-kotlin/tree/master/examples/protos/src/main/proto/io/grpc/examples
 [Quick start]: ../quickstart/

--- a/content/en/docs/languages/node/basics.md
+++ b/content/en/docs/languages/node/basics.md
@@ -15,11 +15,11 @@ By walking through this example you'll learn how to:
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
 with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the
 [proto3](https://github.com/google/protobuf/releases) version of the protocol
 buffers language. You can find out more in the
-[proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3).
+[proto3 language guide](https://protobuf.dev/programming-guides/proto3).
 
 ### Why use gRPC?
 
@@ -65,7 +65,7 @@ client interface code - if you don't already, follow the setup instructions in
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
 [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/languages/objective-c/basics.md
+++ b/content/en/docs/languages/objective-c/basics.md
@@ -14,13 +14,13 @@ By walking through this example you'll learn how to:
 - Use the Objective-C gRPC API to write a simple client for your service.
 
 It assumes a passing familiarity with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
 buffers language: you can find out more in
 the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and the
+guide](https://protobuf.dev/programming-guides/proto3) and the
 [Objective-C generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/objective-c-generated).
+guide](https://protobuf.dev/reference/objective-c/objective-c-generated).
 
 ### Why use gRPC?
 
@@ -88,7 +88,7 @@ uses that library.
 
 First let's look at how the service we're using is defined. A gRPC *service* and
 its method *request* and *response* types using [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file for our example in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/languages/objective-c/quickstart.md
+++ b/content/en/docs/languages/objective-c/quickstart.md
@@ -119,7 +119,7 @@ Now let's look at how to update the application with an extra method on the
 server for the client to call. Our gRPC service is defined using Protocol
 Buffers; you can find out lots more about how to define a service in a `.proto`
 file in Protocol Buffers
-[website](https://developers.google.com/protocol-buffers/). For now all you
+[website](https://protobuf.dev/). For now all you
 need to know is that both the server and the client "stub" have a `SayHello`
 RPC method that takes a `HelloRequest` parameter from the client and returns a
 `HelloResponse` from the server, and that this method is defined like this:

--- a/content/en/docs/languages/php/basics.md
+++ b/content/en/docs/languages/php/basics.md
@@ -14,7 +14,7 @@ By walking through this example you'll learn how to:
 - Use the PHP gRPC API to write a simple client for your service.
 
 It assumes a passing familiarity with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the proto2 version of the protocol
 buffers language.
 
@@ -90,7 +90,7 @@ stub that uses that library.
 
 First let's look at how the service we're using is defined. A gRPC *service* and
 its method *request* and *response* types using [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file for our example in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/languages/python/basics.md
+++ b/content/en/docs/languages/python/basics.md
@@ -15,11 +15,11 @@ By walking through this example you'll learn how to:
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
 with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 find out more in the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and [Python
+guide](https://protobuf.dev/programming-guides/proto3) and [Python
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/python-generated).
+guide](https://protobuf.dev/reference/python/python-generated).
 
 ### Why use gRPC?
 
@@ -51,7 +51,7 @@ client interface code - if you don't already, follow the setup instructions in
 Your first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
 [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/languages/ruby/basics.md
+++ b/content/en/docs/languages/ruby/basics.md
@@ -14,11 +14,11 @@ By walking through this example you'll learn how to:
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
 with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
+buffers](https://protobuf.dev/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
 buffers language: you can find out more in
 the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3).
+guide](https://protobuf.dev/programming-guides/proto3).
 
 ### Why use gRPC?
 
@@ -51,7 +51,7 @@ client interface code - if you don't already, follow the setup instructions in
 Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to
 define the gRPC *service* and the method *request* and *response* types using
 [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
+buffers](https://protobuf.dev/overview). You can
 see the complete .proto file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 

--- a/content/en/docs/platforms/android/java/basics.md
+++ b/content/en/docs/platforms/android/java/basics.md
@@ -12,7 +12,7 @@ By walking through this example you'll learn how to:
 - Generate client code using the protocol buffer compiler.
 - Use the Java gRPC API to write a simple mobile client for your service.
 
-It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar with [protocol buffers](https://protobuf.dev/overview).
 This guide also does not cover anything on the server side. You can check the [Java pages](/docs/languages/java/) for more information.
 
 ### Why use gRPC?
@@ -39,7 +39,7 @@ interface code - if you don't already, follow the setup instructions in the
 
 ### Defining the service
 
-Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [routeguide/app/src/main/proto/route_guide.proto](https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
+Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grpc/introduction/)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://protobuf.dev/overview). You can see the complete .proto file in [routeguide/app/src/main/proto/route_guide.proto](https://github.com/grpc/grpc-java/blob/{{< param grpc_vers.java >}}/examples/android/routeguide/app/src/main/proto/route_guide.proto).
 
 As we're generating Java code in this example, we've specified a `java_package` file option in our .proto:
 

--- a/content/en/docs/platforms/web/basics.md
+++ b/content/en/docs/platforms/web/basics.md
@@ -15,7 +15,7 @@ By walking through this example you'll learn how to:
 - Use the gRPC-Web API to write a simple client for your service.
 
 It assumes a passing familiarity with [protocol
-buffers](https://developers.google.com/protocol-buffers/docs/overview).
+buffers](https://protobuf.dev/overview).
 
 ### Why use gRPC and gRPC-Web? {#why-grpc}
 
@@ -198,5 +198,5 @@ $ npx webpack client.js
 
 Now embed `dist/main.js` into your project and see it in action!
 
-[protobuf documentation]:https://developers.google.com/protocol-buffers/
+[protobuf documentation]:https://protobuf.dev/
 [main page]:/docs/

--- a/content/en/docs/protoc-installation.md
+++ b/content/en/docs/protoc-installation.md
@@ -80,9 +80,9 @@ If you'd like to build the protocol compiler from sources, or access older
 versions of the pre-compiled binaries, see [Download Protocol
 Buffers][download].
 
-[download]: https://developers.google.com/protocol-buffers/docs/downloads
+[download]: https://protobuf.dev/downloads
 [github.com/google/protobuf/releases]: https://github.com/google/protobuf/releases
 [Homebrew]: https://brew.sh
-[latest release]: https://developers.google.com/protocol-buffers/docs/downloads#release-packages
+[latest release]: https://protobuf.dev/downloads#release-packages
 [pb]: https://developers.google.com/protocol-buffers
-[proto3]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3]: https://protobuf.dev/programming-guides/proto3

--- a/content/en/docs/what-is-grpc/introduction.md
+++ b/content/en/docs/what-is-grpc/introduction.md
@@ -110,9 +110,9 @@ version), we recommend that you use proto3 with gRPC as it lets you use the
 full range of gRPC-supported languages, as well as avoiding compatibility
 issues with proto2 clients talking to proto3 servers and vice versa.
 
-[formal specification]: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec
+[formal specification]: https://protobuf.dev/reference/protobuf/proto3-spec
 [golang/protobuf official package]: https://pkg.go.dev/google.golang.org/protobuf
-[proto3 language guide]: https://developers.google.com/protocol-buffers/docs/proto3
+[proto3 language guide]: https://protobuf.dev/programming-guides/proto3
 [protocol buffers GitHub repo]: https://github.com/google/protobuf/releases
-[protocol buffers]: https://developers.google.com/protocol-buffers/docs/overview
-[reference documentation]: https://developers.google.com/protocol-buffers/docs/reference/overview
+[protocol buffers]: https://protobuf.dev/overview
+[reference documentation]: https://protobuf.dev/reference


### PR DESCRIPTION
The Protocol Buffers documentation URL has moved from developers.google.com to protobuf.dev. See notice on top of https://developers.google.com/protocol-buffers:

![image](https://user-images.githubusercontent.com/1782590/215679547-c68047c4-d486-4177-9a80-44a030a0967e.png)

Let's update all references to the protocol buffer documentation to use the new URL.