### PR TITLE
doc: Use f-strings instead of %-s in Python quickstart

### DIFF
--- a/content/en/docs/languages/python/quickstart.md
+++ b/content/en/docs/languages/python/quickstart.md
@@ -172,10 +172,10 @@ this:
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
   def SayHello(self, request, context):
-    return helloworld_pb2.HelloReply(message='Hello, %s!' % request.name)
+    return helloworld_pb2.HelloReply(message=f'Hello, {request.name}!')
 
   def SayHelloAgain(self, request, context):
-    return helloworld_pb2.HelloReply(message='Hello again, %s!' % request.name)
+    return helloworld_pb2.HelloReply(message=f'Hello again, {request.name}!')
 ...
 ```
 


### PR DESCRIPTION
Use modern f-string formatting instead of %-s.