### PR TITLE
Kotlin/basics: fix heading level

### DIFF
--- a/content/en/docs/languages/kotlin/basics.md
+++ b/content/en/docs/languages/kotlin/basics.md
@@ -190,7 +190,7 @@ class RouteGuideService(
 }
 ```
 
-#### Simple RPC
+##### Simple RPC
 
 `RouteGuideService` implements all the service methods. Consider the simplest
 method first, `GetFeature()`, which gets a `Point` from the client and returns a


### PR DESCRIPTION
What is the change?
This change fixes the "Simple RPC" heading level in the `basics.md` file of kotlin docs.

Why the change?
This change contributes to https://github.com/grpc/grpc.io/issues/1004