### PR TITLE
Node/basics: Format file extensions in code font

### DIFF
--- a/content/en/docs/languages/node/basics.md
+++ b/content/en/docs/languages/node/basics.md
@@ -10,7 +10,7 @@ to working with gRPC.
 
 By walking through this example you'll learn how to:
 
-- Define a service in a .proto file.
+- Define a service in a `.proto` file.
 - Use the Node.js gRPC API to write a simple client and server for your service.
 
 It assumes that you have read the [Introduction to gRPC](/docs/what-is-grpc/introduction/) and are familiar
@@ -66,10 +66,10 @@ Our first step (as you'll know from the [Introduction to gRPC](/docs/what-is-grp
 define the gRPC *service* and the method *request* and *response* types using
 [protocol
 buffers](https://protobuf.dev/overview). You can
-see the complete .proto file in
+see the complete `.proto` file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{< param grpc_vers.core >}}/examples/protos/route_guide.proto).
 
-To define a service, you specify a named `service` in your .proto file:
+To define a service, you specify a named `service` in your `.proto` file:
 
 ```protobuf
 service RouteGuide {


### PR DESCRIPTION
What is the change?
This change formats file extensions in code font in the `basics.md` file of Node docs.

Why the change?
This change contributes to https://github.com/grpc/grpc.io/issues/163