### PR TITLE
Go/basics: Format file extensions in code font

### DIFF
--- a/content/en/docs/languages/go/basics.md
+++ b/content/en/docs/languages/go/basics.md
@@ -57,7 +57,7 @@ define the gRPC *service* and the method *request* and *response* types using
 For the complete `.proto` file, see
 [routeguide/route_guide.proto](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/routeguide/route_guide.proto).
 
-To define a service, you specify a named `service` in your .proto file:
+To define a service, you specify a named `service` in your `.proto` file:
 
 ```proto
 service RouteGuide {
@@ -118,7 +118,7 @@ all of which are used in the `RouteGuide` service:
   rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
   ```
 
-Our .proto file also contains protocol buffer message type definitions for all
+Our `.proto` file also contains protocol buffer message type definitions for all
 the request and response types used in our service methods - for example, here's
 the `Point` message type:
 


### PR DESCRIPTION
What is the change?
This change formats file extensions in code font in the `basics.md` file of Go docs.

Why the change?
This change contributes to https://github.com/grpc/grpc.io/issues/163