### PR TITLE
Clarify what GCP platforms are supported by gRPC's ALTS libraries.

### DIFF
--- a/content/en/docs/guides/auth.md
+++ b/content/en/docs/guides/auth.md
@@ -27,7 +27,8 @@ The following authentication mechanisms are built-in to gRPC:
 - **ALTS**: gRPC supports
   [ALTS](https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security)
   as a transport security mechanism, if the application is running on
-  [Google Cloud Platform (GCP)](https://cloud.google.com).
+  [Compute Engine](https://cloud.google.com/compute) or
+  [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
   For details, see one of the following
   language-specific pages:
   [ALTS in C++]({{< relref "docs/languages/cpp/alts" >}}),

--- a/layouts/shortcodes/docs/auth_alts.md
+++ b/layouts/shortcodes/docs/auth_alts.md
@@ -18,10 +18,9 @@ ALTS in gRPC has the following features:
 gRPC users can configure their applications to use ALTS as a transport security
 protocol with few lines of code.
 
-Note that ALTS is fully functional if the application runs on
-[Google Cloud Platform](https://cloud.google.com). ALTS could be run on any
-platforms with a pluggable
-[ALTS handshaker service](https://github.com/grpc/grpc/blob/7e367da22a137e2e7caeae8342c239a91434ba50/src/proto/grpc/gcp/handshaker.proto#L224-L234).
+Note that ALTS is fully functional if the application runs on 
+[Compute Engine](https://cloud.google.com/compute) or
+[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
 
 {{ with .Page.Params.code.client_credentials -}}
 


### PR DESCRIPTION
The current wording in the documentation has led to confusion among some users of gRPC's ALTS libraries (example: https://github.com/grpc/grpc-go/issues/6252). This PR clarifies the GCP platforms on which gRPC's ALTS libraries are supported.