### PR TITLE
Update Grpc C# future blogpost with latest updates

### DIFF
--- a/content/en/blog/grpc-csharp-future.md
+++ b/content/en/blog/grpc-csharp-future.md
@@ -7,7 +7,7 @@ author:
   link: https://github.com/jtattermusch
 ---
 
-**Update 2023-10-02: The maintenance period for `Grpc.Core` has been extended again, until at least October 2024. See [announcement][updates2023] up to date info on `Grpc.Core`.**
+**Update 2023-10-02: The maintenance period for `Grpc.Core` has been extended again, until at least October 2024. See [announcement][updates2023] for up to date info on `Grpc.Core`.**
 
 **Update 2022-05-03: The maintenance period for `Grpc.Core` has been extended until May 2023. See [announcement][updates2022] for more info on the future of `Grpc.Core`.**
 

--- a/content/en/blog/grpc-csharp-future.md
+++ b/content/en/blog/grpc-csharp-future.md
@@ -7,7 +7,9 @@ author:
   link: https://github.com/jtattermusch
 ---
 
-**Update 2022-05-03: The maintenance period for `Grpc.Core` has been extended until May 2023. See [announcement][updates] for more info on the future of `Grpc.Core`.**
+**Update 2023-10-02: The maintenance period for `Grpc.Core` has been extended again, until at least October 2024. See [announcement][updates2023] up to date info on `Grpc.Core`.**
+
+**Update 2022-05-03: The maintenance period for `Grpc.Core` has been extended until May 2023. See [announcement][updates2022] for more info on the future of `Grpc.Core`.**
 
 **TL;DR** grpc-dotnet (the
 [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client/) and
@@ -252,4 +254,5 @@ any other of the main [gRPC community channels]({{<relref community >}}).
 
 [ga]: {{< relref grpc-on-dotnetcore >}}
 [grpc-io]: https://groups.google.com/g/grpc-io
-[updates]: https://groups.google.com/g/grpc-io/c/OTj5mb1qzb0
+[updates2022]: https://groups.google.com/g/grpc-io/c/OTj5mb1qzb0
+[updates2023]: https://groups.google.com/g/grpc-io/c/iEalUhV4VrU


### PR DESCRIPTION
Since most places in the documentation refer to the blogpost as authoritative info on Grpc.Core's future.