### PR TITLE
Fix typo in Kotlin quickstart

### DIFF
--- a/content/en/docs/languages/kotlin/quickstart.md
+++ b/content/en/docs/languages/kotlin/quickstart.md
@@ -109,7 +109,7 @@ Remember to save the file!
 
 ### Update the app
 
-When you build the example, the build process regenerates `HelloWorldGrpcKt.kt`,
+When you build the example, the build process regenerates `HelloWorldProtoGrpcKt.kt`,
 which contains the generated gRPC client and server classes. This also
 regenerates classes for populating, serializing, and retrieving our request and
 response types.

--- a/content/en/docs/platforms/android/kotlin/quickstart.md
+++ b/content/en/docs/platforms/android/kotlin/quickstart.md
@@ -135,7 +135,7 @@ Remember to save the file!
 
 ### Update the app
 
-When you build the example, the build process regenerates `HelloWorldGrpcKt.kt`,
+When you build the example, the build process regenerates `HelloWorldProtoGrpcKt.kt`,
 which contains the generated gRPC client and server classes. This also
 regenerates classes for populating, serializing, and retrieving our request and
 response types.


### PR DESCRIPTION
Same changes as in #984 where we could not get the CLA signed.