### PR TITLE
update deprecated http2_protocol_options envoy field

### DIFF
--- a/content/en/docs/platforms/web/basics.md
+++ b/content/en/docs/platforms/web/basics.md
@@ -113,7 +113,11 @@ static_resources:
   - name: echo_service
     connect_timeout: 0.25s
     type: LOGICAL_DNS
-    http2_protocol_options: {}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: echo_service


### PR DESCRIPTION
Replace the deprecated `http2_protocol_options` field - https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-http2-protocol-options

A similar change was done in all envoy examples a while ago: https://github.com/envoyproxy/envoy/pull/15563
