### PR TITLE
Remove flag.Parse() line from go basic guide

### DIFF
--- a/content/en/docs/languages/go/basics.md
+++ b/content/en/docs/languages/go/basics.md
@@ -359,8 +359,7 @@ so that clients can actually use our service. The following snippet shows how we
 do this for our `RouteGuide` service:
 
 ```go
-flag.Parse()
-lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 if err != nil {
   log.Fatalf("failed to listen: %v", err)
 }


### PR DESCRIPTION
It's kind of unnecessary to put here `flag.Parse()` line. I guess it became from some of existing gRPC guides, where port of server receives using command line arguments.