### PR TITLE
Updated protoc version for gRPC 1.62

### DIFF
--- a/content/en/docs/protoc-installation.md
+++ b/content/en/docs/protoc-installation.md
@@ -2,7 +2,7 @@
 title: Protocol Buffer Compiler Installation
 linkTitle: Protoc Installation
 description: How to install the protocol buffer compiler.
-protoc-version: 3.15.8
+protoc-version: 25.1
 toc_hide: true
 ---
 


### PR DESCRIPTION
Updated the protoc-version to have the same version that gRPC 1.62 is built with.