### PR TITLE
Use absolute paths instead of absolute URLs

### DIFF
--- a/content/en/docs/guides/cancellation.md
+++ b/content/en/docs/guides/cancellation.md
@@ -8,7 +8,7 @@ description: >-
 
 When a gRPC client is no longer interested in the result of an RPC call, it may
 _cancel_ to signal this discontinuation of interest to the server.
-[Deadline](https://grpc.io/docs/guides/deadlines/) expiration and I/O errors
+[Deadline](/docs/guides/deadlines/) expiration and I/O errors
 also trigger cancellation.  When an RPC is cancelled, the server should stop
 any ongoing computation and end its side of the stream. Often, servers are also
 clients to upstream servers, so that cancellation operation should ideally

--- a/content/en/docs/guides/custom-backend-metrics.md
+++ b/content/en/docs/guides/custom-backend-metrics.md
@@ -66,5 +66,5 @@ For more details, please see gRPC [proposal A51].
 [ORCA]: https://github.com/cncf/xds/blob/main/xds/data/orca/v3/orca_load_report.proto
 [Java example]: https://github.com/grpc/grpc-java/tree/master/examples/example-orca
 [Go example]: https://github.com/grpc/grpc-go/tree/master/examples/features/orca
-[custom load balancing guide]: https://grpc.io/docs/guides/custom-load-balancing/
+[custom load balancing guide]: /docs/guides/custom-load-balancing/
 [custom load balancer]: https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md

--- a/content/en/docs/guides/metadata.md
+++ b/content/en/docs/guides/metadata.md
@@ -42,7 +42,7 @@ gRPC metadata is useful for a variety of purposes, such as:
 * **Internal usages**: gRPC uses HTTP/2 headers and trailers, which will be
   integrated with the metadata specified by your application.
 
-See [Concepts guide](https://grpc.io/docs/guides/concepts.html#metadata)
+See [Core Concepts](/docs/what-is-grpc/core-concepts/#metadata)
 
 #### Be Aware
 

--- a/content/en/docs/guides/service-config.md
+++ b/content/en/docs/guides/service-config.md
@@ -120,7 +120,7 @@ The below example does the following:
 
 [protobuf definition]:https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
 [timeout]:/docs/guides/deadlines/
-[Retry]:/docs/guides/retry/
+[Retry]:https://grpc.io/docs/guides/retry/
 [health checking]:/docs/guides/health-checking/
 [Hedging]:/docs/guides/request-hedging/
 [wait-for-ready]:/docs/guides/wait-for-ready/

--- a/content/en/docs/guides/service-config.md
+++ b/content/en/docs/guides/service-config.md
@@ -119,11 +119,11 @@ The below example does the following:
 ```
 
 [protobuf definition]:https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
-[timeout]:https://grpc.io/docs/guides/deadlines/
-[Retry]:https://grpc.io/docs/guides/retry/
-[health checking]:https://grpc.io/docs/guides/health-checking/
-[Hedging]:https://grpc.io/docs/guides/request-hedging/
-[wait-for-ready]:https://grpc.io/docs/guides/wait-for-ready/
+[timeout]:/docs/guides/deadlines/
+[Retry]:/docs/guides/retry/
+[health checking]:/docs/guides/health-checking/
+[Hedging]:/docs/guides/request-hedging/
+[wait-for-ready]:/docs/guides/wait-for-ready/
 [name resolution mechanism]:https://github.com/grpc/grpc/blob/master/doc/naming.md
 [stored as TXT records]:https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md
 


### PR DESCRIPTION
When you specify grpc.io in a URL, it is considered a separate site and gets the "linking away" anchor behavior, with the icon and opening in a new tab. Also, such links don't work properly when running locally or using the PR deploy preview.

In metadata.md, the concepts guide moved locations (see layouts/index.redirects), so let's inline that redirect.