### PR TITLE
Update basics.md

### DIFF
--- a/content/en/docs/languages/dart/basics.md
+++ b/content/en/docs/languages/dart/basics.md
@@ -290,8 +290,7 @@ Future<RouteSummary> recordRoute(
   await for (var location in request) {
     if (!timer.isRunning) timer.start();
     pointCount++;
-    final feature = featuresDb.firstWhere((f) => f.location == location,
-        orElse: () => null);
+    final feature = featuresDb.firstWhereOrNull((f) => f.location == location);
     if (feature != null) {
       featureCount++;
     }


### PR DESCRIPTION
In this example firstWhere() causes compile time error if null passed to its orElse named parameter in dart 3. I fixed it by using firstWhereOrNull() with no orElse named parameter.