### PR TITLE
Change gRPC-go version to 1.63

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.62.0
-    go: v1.62.0
+    go: v1.63.0
     java: v1.62.2
     node: "@grpc/grpc-js@1.9.0"
   font_awesome_version: 5.12.1


### PR DESCRIPTION
Released: https://github.com/grpc/grpc-go/releases/tag/v1.63.0