### PR TITLE
script for gtm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ enableGitInfo: true
 enableRobotsTXT: true
 
 params:
+  gtmID: "GTM-55D2HXLW"
   copyright: gRPC Authors
   repo: &repo https://github.com/grpc/grpc.io
   github_repo: *repo

--- a/layouts/partials/gtm-noscript.html
+++ b/layouts/partials/gtm-noscript.html
@@ -1,0 +1,8 @@
+{{ if .Site.Params.gtmID }}
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ .Site.Params.gtmID }}"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{ end }}

--- a/layouts/partials/gtm.html
+++ b/layouts/partials/gtm.html
@@ -1,0 +1,11 @@
+{{ if .Site.Params.gtmID }}
+<!-- Google Tag Manager -->
+<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ .Site.Params.gtmID }}');
+</script>
+<!-- End Google Tag Manager -->
+{{ end }}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,1 +1,4 @@
 {{/* Use this file to include anything you wish to append to the end of the body tag */ -}}
+<!-- GTM code snippet for js disabled browsers -->
+ <!-- Placing the noscript code snippet at the end of the body can lead to missing some events during page load, but since users with JavaScript disabled browsers are rare, this placement is acceptable. -->
+{{ partial "gtm-noscript.html" . }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,2 +1,3 @@
 {{ partial "meta.html" . -}}
 {{ partial "favicons.html" . -}}
+{{ partial "gtm.html" . }}


### PR DESCRIPTION
Created partials to embed Google Tag Manager (GTM) script. GTM container ID is dynamically fetched from config.yaml, ensuring that tags fired are sent to their assigned GTM container