### PR TITLE
Modify banner styling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/grpc/grpc.io-docsy.git
-	branch = grpc.io

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "themes/docsy"]
+	path = themes/docsy
+	url = https://github.com/grpc/grpc.io-docsy.git
+	branch = grpc.io

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -9,11 +9,6 @@ what the workaround is for
   cursor: pointer;
 }
 
-// ensure enough space for banner without overlapping with the main section
-.banner-container { 
-  height: 60px;
-}
-
 // External link icon
 a > .fa-external-link-alt::before,
 a > span > .fa-external-link-alt::before {
@@ -239,7 +234,7 @@ c - Component (Aware of its content/context...)
 // Object
 .o-banner {
   width: 100%;
-  position: absolute;
+  position: relative;
   padding-top: 15px;
   // keep banner's z-index value less than the navbar, so that banner moves beneath the navbar when user scrolls the page
   z-index: $navbar-z-index - 1;
@@ -250,14 +245,12 @@ c - Component (Aware of its content/context...)
   & p {
     padding: 0.5rem;
   }
+  padding-bottom: 0.01rem;
 }
 
 @include media-breakpoint-down(sm){
   .o-banner{
-    top: 6rem;
-  }
-  .td-sidebar{
-    padding-top: 1rem;
+    top: 0rem;
   }
 }
 

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -252,6 +252,13 @@ c - Component (Aware of its content/context...)
   }
 }
 
+// Adjust the top value for smaller screens of banner banner medium and large screens to avoid overlapping with banner
+@media (max-width: 768px), (max-width: 576px) {
+  .o-banner {
+    top: 6rem; 
+  }
+}
+
 .o-icon {
   margin-right: 0.25rem;
 }

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -9,6 +9,11 @@ what the workaround is for
   cursor: pointer;
 }
 
+//ensure enough space for banner without overlapping with the main section
+.banner-container { 
+  height: 60px;
+}
+
 // External link icon
 a > .fa-external-link-alt::before,
 a > span > .fa-external-link-alt::before {
@@ -229,10 +234,9 @@ c - Component (Aware of its content/context...)
 // Object
 .o-banner {
   width: 100%;
-  position: fixed;
-  margin-left: -15px;
+  position: absolute;
   padding-top: 15px;
-  z-index: 32;
+  z-index: $navbar-z-index - 1;
   top: 4rem;
   background: $light;
   text-align: center;

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -241,6 +241,7 @@ c - Component (Aware of its content/context...)
   width: 100%;
   position: absolute;
   padding-top: 15px;
+  // keep banner's z-index value less than the navbar, so that banner moves beneath the navbar when user scrolls the page
   z-index: $navbar-z-index - 1;
   top: 4rem;
   background: $light;

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -248,6 +248,7 @@ c - Component (Aware of its content/context...)
   padding-bottom: 0.01rem;
 }
 
+// Ensure no empty space left when navbar changes it's position from fixed to relative on small screens
 @include media-breakpoint-down(sm){
   .o-banner{
     top: 0rem;

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -49,6 +49,11 @@ sections site wide to the original site's background svg.
   display: none;
 }
 
+//use variable for navbar z-index as banner z-index depends on it
+.td-navbar {
+  z-index: $navbar-z-index;
+}
+
 // This adds rounded corners to the search inputs, since a Docsy
 // flag affecting these and other elements has been disabled.
 .td-search-input {

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -49,12 +49,6 @@ sections site wide to the original site's background svg.
   display: none;
 }
 
-// Override Docsy theme padding values to reduce vertical space taken up by the hero section
-.td-default main > section:first-of-type {
-  padding-top: 6rem;
-  padding-bottom: 3rem;
-}
-
 // use variable for navbar z-index as banner z-index depends on it
 .td-navbar {
   z-index: $navbar-z-index;

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -252,10 +252,12 @@ c - Component (Aware of its content/context...)
   }
 }
 
-// Adjust the top value for smaller screens of banner banner medium and large screens to avoid overlapping with banner
-@media (max-width: 768px), (max-width: 576px) {
-  .o-banner {
-    top: 6rem; 
+@include media-breakpoint-down(sm){
+  .o-banner{
+    top: 6rem;
+  }
+  .td-sidebar{
+    padding-top: 1rem;
   }
 }
 

--- a/assets/scss/_grpc.scss
+++ b/assets/scss/_grpc.scss
@@ -9,7 +9,7 @@ what the workaround is for
   cursor: pointer;
 }
 
-//ensure enough space for banner without overlapping with the main section
+// ensure enough space for banner without overlapping with the main section
 .banner-container { 
   height: 60px;
 }
@@ -49,7 +49,13 @@ sections site wide to the original site's background svg.
   display: none;
 }
 
-//use variable for navbar z-index as banner z-index depends on it
+// Override Docsy theme padding values to reduce vertical space taken up by the hero section
+.td-default main > section:first-of-type {
+  padding-top: 6rem;
+  padding-bottom: 3rem;
+}
+
+// use variable for navbar z-index as banner z-index depends on it
 .td-navbar {
   z-index: $navbar-z-index;
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -17,3 +17,5 @@ $display4-weight: $_font-weight-light;
 $link-color: #379c9c;
 
 $enable-rounded: false;
+
+$navbar-z-index: 32;

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,11 +1,13 @@
 {{ if site.Params.show_banner -}}
-<div class="o-banner">
-  <p>
-    gRPConf 2024 is on <strong>Aug. 27th!</strong> -
-    <a href="https://events.linuxfoundation.org/grpconf/" target="_blank" rel="noopener">
-      <strong>Register now</strong>
-    </a>
-    ($50 until Jul 30th)
-  </p>
+<div class="banner-container">
+  <div class="o-banner">
+    <p>
+      gRPConf 2024 is on <strong>Aug. 27th!</strong> -
+      <a href="https://events.linuxfoundation.org/grpconf/" target="_blank" rel="noopener">
+        <strong>Register now</strong>
+      </a>
+      ($50 until Jul 30th)
+    </p>
+  </div>
 </div>
 {{ end -}}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,13 +1,11 @@
 {{ if site.Params.show_banner -}}
-<div class="banner-container">
-  <div class="o-banner">
-    <p>
-      gRPConf 2024 is on <strong>Aug. 27th!</strong> -
-      <a href="https://events.linuxfoundation.org/grpconf/" target="_blank" rel="noopener">
-        <strong>Register now</strong>
-      </a>
-      ($50 until Jul 30th)
+<div class="o-banner">
+  <p>
+    gRPConf 2024 is on <strong>Aug. 27th!</strong> -
+    <a href="https://events.linuxfoundation.org/grpconf/" target="_blank" rel="noopener">
+      <strong>Register now</strong>
+    </a>
+    ($50 until Jul 30th)
     </p>
   </div>
-</div>
 {{ end -}}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -6,6 +6,6 @@
       <strong>Register now</strong>
     </a>
     ($50 until Jul 30th)
-    </p>
-  </div>
+  </p>
+</div>
 {{ end -}}

--- a/layouts/shortcodes/page/header.html
+++ b/layouts/shortcodes/page/header.html
@@ -1,12 +1,12 @@
 {{ $title := $.Page.Params.title -}}
 {{ $desc  := $.Page.Params.description | markdownify -}}
 <div class="text-left">
-  <h1 class="display-1 mb-5">
+  <h1 class="display-1">
     {{- $title -}}
   </h1>
 
   {{- with $desc -}}
-  <h3 class="font-weight-light">
+  <h3 class="font-weight-light mt-5">
     {{- . -}}
   </h3>
   {{ end -}}


### PR DESCRIPTION
modified the current banner position from fixed to absolute to ensure that it does not consume screen space while scrolling and adjusted the banner z-index so the banner moves beneath the navbar while scrolling.
NOTE: [#9](https://github.com/grpc/grpc.io-docsy/pull/9) has to merged before merging this PR, as the styles defined here are applied correctly when the banner is in header section.