### PR TITLE
grpc-go: update versions

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -7,7 +7,7 @@ spelling: cSpell:ignore Fatalf GOPATH
 
 ### Prerequisites
 
-- **[Go][]**, any one of the **three latest major** [releases of Go][].
+- **[Go][]**, any one of the **two latest major** [releases of Go][].
 
   For installation instructions, see Go's [Getting Started][] guide.
 
@@ -21,8 +21,8 @@ spelling: cSpell:ignore Fatalf GOPATH
    1. Install the protocol compiler plugins for Go using the following commands:
 
       ```sh
-      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
-      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+      $ go install google.golang.org/protobuf/cmd/protoc-gen-go
+      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
       ```
 
    2. Update your `PATH` so that the `protoc` compiler can find the plugins:


### PR DESCRIPTION
Two changes:

1. Since https://github.com/grpc/grpc-go/issues/7249, gRPC-Go only supports the last two versions of Golang. Similar to Golang policy itself
2. Install the latest protoc plugins 

cc: @dfawley 