### PR TITLE
Add missing version specifications for go install

### DIFF
--- a/content/en/docs/languages/go/quickstart.md
+++ b/content/en/docs/languages/go/quickstart.md
@@ -21,8 +21,8 @@ spelling: cSpell:ignore Fatalf GOPATH
    1. Install the protocol compiler plugins for Go using the following commands:
 
       ```sh
-      $ go install google.golang.org/protobuf/cmd/protoc-gen-go
-      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+      $ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
       ```
 
    2. Update your `PATH` so that the `protoc` compiler can find the plugins:


### PR DESCRIPTION
When I ran `go install google.golang.org/protobuf/cmd/protoc-gen-go` and `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc`, following error was showed.

```sh
go: 'go install' requires a version when current directory is not in a module
        Try 'go install google.golang.org/protobuf/cmd/protoc-gen-go@latest' to install the latest version
```

I think version specification is necessary.

Go version: `go version go1.22.6 darwin/arm64`