### PR TITLE
Add Windows as a supported platform for PHP

### DIFF
--- a/data/officially_supported_lang_os.yaml
+++ b/data/officially_supported_lang_os.yaml
@@ -29,7 +29,7 @@
   os: [macOS 10.10+, iOS 9.0+]
   compilers: [Xcode 12+]
 - language: PHP
-  os: [Linux, Mac]
+  os: [Windows, Linux, Mac]
   compilers: [PHP 7.0+]
 - language: Python
   os: [Windows, Linux, Mac]


### PR DESCRIPTION
PHP Windows DLLs are available.

- https://pecl.php.net/package/grpc
- https://github.com/grpc/grpc/tree/master/src/php
