### PR TITLE
Update link to Square blog in FAQ

### DIFF
--- a/content/en/docs/what-is-grpc/faq.md
+++ b/content/en/docs/what-is-grpc/faq.md
@@ -27,7 +27,7 @@ The main usage scenarios:
 
 gRPC is a [Cloud Native Computing Foundation](https://cncf.io) (CNCF) project.
 
-Google has been using a lot of the underlying technologies and concepts in gRPC for a long time. The current implementation is being used in several of Google’s cloud products and Google externally facing APIs. It is also being used by [Square](https://corner.squareup.com/2015/02/grpc.html), [Netflix](https://github.com/Netflix/ribbon), [CoreOS](https://blog.gopheracademy.com/advent-2015/etcd-distributed-key-value-store-with-grpc-http2/), [Docker](https://blog.docker.com/2015/12/containerd-daemon-to-control-runc/), [CockroachDB](https://github.com/cockroachdb/cockroach), [Cisco](https://github.com/CiscoDevNet/grpc-getting-started), [Juniper Networks](https://github.com/Juniper/open-nti) and many other organizations and individuals.
+Google has been using a lot of the underlying technologies and concepts in gRPC for a long time. The current implementation is being used in several of Google’s cloud products and Google externally facing APIs. It is also being used by [Square](https://developer.squareup.com/blog/grpc-cross-platform-open-source-rpc-over-http-2/), [Netflix](https://github.com/Netflix/ribbon), [CoreOS](https://blog.gopheracademy.com/advent-2015/etcd-distributed-key-value-store-with-grpc-http2/), [Docker](https://blog.docker.com/2015/12/containerd-daemon-to-control-runc/), [CockroachDB](https://github.com/cockroachdb/cockroach), [Cisco](https://github.com/CiscoDevNet/grpc-getting-started), [Juniper Networks](https://github.com/Juniper/open-nti) and many other organizations and individuals.
 
 ### Which programming languages are supported?
 


### PR DESCRIPTION
The old link to the Square blog post about partnering on grpc no longer worked and redirected to the Square blog home.

Old defunct link: https://corner.squareup.com/2015/02/grpc.html
New link: https://developer.squareup.com/blog/grpc-cross-platform-open-source-rpc-over-http-2/