### PR TITLE
 custom-name-resolution: Update unix resolver scheme

### DIFF
--- a/content/en/docs/guides/custom-name-resolution.md
+++ b/content/en/docs/guides/custom-name-resolution.md
@@ -20,7 +20,7 @@ used. However, various other name resolution mechanisms may be used:
 |-|-|-|
 |DNS|`grpc.io:50051`|By default, DNS is assumed.|
 |DNS|`dns:///grpc.io:50051`|The extra slash is used to provide an authority|
-|Unix Domain Socket|`uds:///run/containerd/containerd.sock`|
+|Unix Domain Socket|`unix:///run/containerd/containerd.sock`|
 |xDS|`xds:///wallet.grpcwallet.io`||
 |IPv4|`ipv4:198.51.100.123:50051`|Only supported in some languages|
 


### PR DESCRIPTION
The scheme for the unix resolver is `unix` and not `uds` in the following gRPC implementation:
1. [Go](https://github.com/grpc/grpc-go/blob/ec2d624ac9eebaeacb5ff3be128b3d6e0c4f9fec/internal/resolver/unix/unix.go#L29)
2. [c-core/python](https://github.com/grpc/grpc/blob/3afc5d692a7105ffd22182f9d064212b4aeed5c4/examples/python/uds/README.md?plain=1#L13-L14)
3. [Java](https://github.com/grpc/grpc-java/blob/6cd007d0d0603187224231079107ee79e2b0a539/netty/src/main/java/io/grpc/netty/UdsNameResolverProvider.java#L32)