### PR TITLE
grpc-io: Update Android quickstart docs with AndroidX and java version guidance in quickstart.md

### DIFF
--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -32,8 +32,9 @@ weight: 10
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
 
-  Since the AGP version used is 7.x, you need to use Java versions 17 - 21 to avoid DexWorkAction / D8 errors.
-{{% /alert %}}
+For AGP 7.x, it's recommended to use Java 11, 17, or 20 to avoid DexWorkAction / D8 issues.
+While Java 21 might technically work, it's safer to avoid it due to potential compatibility quirks.
+Note that AGP 8.x and later explicitly require Java 17 as the minimum version.{{% /alert %}}
 
 ### Get the example code
 

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -33,7 +33,7 @@ weight: 10
   local (non-Android) computer.
 
 For AGP 7.x, it's recommended to use Java 11 - 20 to avoid DexWorkAction / D8 issues.
-Java 21+ (which produces bytecode version 65+) is not supported by AGP 7.x and will cause build failures due to bytecode incompatibility. AGP 7.x supports up to bytecode version 61.
+Java 21+ (which produces bytecode version 65+) is not supported by AGP 7.x and will result in build failures due to bytecode incompatibility. AGP 7.x supports up to bytecode version 61.
 Note that AGP 8.x and later explicitly require Java 17 as the minimum version.{{% /alert %}}
 
 ### Get the example code

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -8,7 +8,7 @@ weight: 10
 
 - [JDK][] version 11 or higher.
 
-   1. The example uses AGP 7.x (compatible with Java 11–17). If you upgrade it to AGP 8.x requires Java 17+.
+   1. The example uses AGP 7.x (compatible with Java 11–17). If you upgrade it to AGP 8.x, it requires Java 17+.
 
 - Android SDK, API level 16 or higher
 

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -34,10 +34,7 @@ weight: 10
   gRPC Java does not support running a server on an Android device. For this
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
-
-For AGP 7.x, it's recommended to use Java 11 - 20 to avoid DexWorkAction / D8 issues.
-Java 21+ (which produces bytecode version 65+) is not supported by AGP 7.x and will result in build failures due to bytecode incompatibility. AGP 7.x supports up to bytecode version 61.
-Note that AGP 8.x and later explicitly require Java 17 as the minimum version.{{% /alert %}}
+{{% /alert %}}
 
 ### Get the example code
 

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -6,7 +6,7 @@ weight: 10
 
 ### Prerequisites
 
-- [JDK][] version 11–17 is required.
+- [JDK][] version 11 or higher.
 
    1. The example uses AGP 7.x (compatible with Java 11–17). If you upgrade it to AGP 8.x requires Java 17+.
 

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -24,10 +24,15 @@ weight: 10
 - An android device set up for [USB debugging][] or an
   [Android Virtual Device][]
 
+- Add the following line in your gradle.properties to ensure compatibility with Android tooling and libraries:
+   **android.useAndroidX=true**
+
 {{% alert title="Note" color="info" %}}
   gRPC Java does not support running a server on an Android device. For this
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
+
+  Since the AGP version used is 7.x, you need to use Java versions 17 - 21 to avoid DexWorkAction / D8 errors.
 {{% /alert %}}
 
 ### Get the example code

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -32,8 +32,8 @@ weight: 10
   quick start, the Android client app will connect to a server running on your
   local (non-Android) computer.
 
-For AGP 7.x, it's recommended to use Java 11, 17, or 20 to avoid DexWorkAction / D8 issues.
-While Java 21 might technically work, it's safer to avoid it due to potential compatibility quirks.
+For AGP 7.x, it's recommended to use Java 11 - 20 to avoid DexWorkAction / D8 issues.
+Java 21+ (which produces bytecode version 65+) is not supported by AGP 7.x and will cause build failures due to bytecode incompatibility. AGP 7.x supports up to bytecode version 61.
 Note that AGP 8.x and later explicitly require Java 17 as the minimum version.{{% /alert %}}
 
 ### Get the example code

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -6,7 +6,10 @@ weight: 10
 
 ### Prerequisites
 
-- [JDK][] version 7 or higher
+- [JDK][] version 11–17 is required.
+
+   1. The example uses AGP 7.x (compatible with Java 11–17). If you upgrade it to AGP 8.x requires Java 17+.
+
 - Android SDK, API level 16 or higher
 
    1. Install [Android Studio][] or the Android [command-line tools][].
@@ -26,6 +29,8 @@ weight: 10
 
 - Add the following line in your gradle.properties to ensure compatibility with Android tooling and libraries:
    **android.useAndroidX=true**
+
+- The examples default to AGP 7.x which needs Java 11 to 17. If you upgrade it to AGP 8.x, it needs Java 17+
 
 {{% alert title="Note" color="info" %}}
   gRPC Java does not support running a server on an Android device. For this

--- a/content/en/docs/platforms/android/java/quickstart.md
+++ b/content/en/docs/platforms/android/java/quickstart.md
@@ -30,8 +30,6 @@ weight: 10
 - Add the following line in your gradle.properties to ensure compatibility with Android tooling and libraries:
    **android.useAndroidX=true**
 
-- The examples default to AGP 7.x which needs Java 11 to 17. If you upgrade it to AGP 8.x, it needs Java 17+
-
 {{% alert title="Note" color="info" %}}
   gRPC Java does not support running a server on an Android device. For this
   quick start, the Android client app will connect to a server running on your


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/11836
Update Android quickstart docs with AndroidX and Java compatibility notes
