### PR TITLE
Update gRPC Go version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.74.0
-    go: v1.74.2
+    go: v1.75.0
     java: v1.73.0
     node: "@grpc/grpc-js@1.9.0"
   font_awesome_version: 5.12.1


### PR DESCRIPTION
Release: https://github.com/grpc/grpc-go/releases/tag/v1.75.0