### PR TITLE
Fix: missing `popd` in quickstart.md for Linux & macOS build steps

### DIFF
--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -191,6 +191,7 @@ the steps of the previous section.
       pushd cmake/build
       cmake -DCMAKE_PREFIX_PATH=$MY_INSTALL_DIR ../..
       make -j 4
+      popd
       ```
 
     - Windows


### PR DESCRIPTION
This pull request adds a missing `popd` command to the Linux & macOS sample build instructions in `content/en/docs/languages/cpp/quickstart.md`.
Previously, the code block used `pushd` to enter the build directory but did not return to the original directory.
Adding `popd `ensures the pushd/popd pair is consistent and improves clarity and shell environment cleanliness.