### PR TITLE
Fixed mixing of Linux and Windows variable substitution format in quickstart.md

### DIFF
--- a/content/en/docs/languages/cpp/quickstart.md
+++ b/content/en/docs/languages/cpp/quickstart.md
@@ -56,7 +56,7 @@ mkdir %MY_INSTALL_DIR%
 Add the local `bin` folder to your path variable, for example:
 
 ```powershell
-set PATH=%PATH%;$MY_INSTALL_DIR\bin
+set PATH=%PATH%;%MY_INSTALL_DIR%\bin
 ```
 
 #### Install cmake


### PR DESCRIPTION
Changed $MY_INSTALL_DIR linux env variable substitution format to windows one %MY_INSTALL_DIR%