### PR TITLE
service-config.md: Use underscores not camelCase

### DIFF
--- a/content/en/docs/guides/service-config.md
+++ b/content/en/docs/guides/service-config.md
@@ -101,8 +101,8 @@ The below example does the following:
 
 ```json
 {
-  "loadBalancingConfig": [ { "round_robin": {} } ],
-  "methodConfig": [
+  "load_balancing_config": [ { "round_robin": {} } ],
+  "method_config": [
     {
       "name": [{}],
       "timeout": "1s"


### PR DESCRIPTION
The service config protobuf specifies JSON names as underscores.

* loadBalancingConfig -> load_balancing_config
* methodConfig -> method_config