### PR TITLE
Remove gRPC Conf US info from banner

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,20 +1,7 @@
 {{ if site.Params.show_banner -}}
 <div class="o-banner">
   <p>
-    Get tickets ($99) for gRPConf 2025 on <strong>Aug. 26th!</strong> -
-    <a href="https://events.linuxfoundation.org/grpconf/" target="_blank" rel="noopener">
-      <strong>Register now</strong>
-    </a>
-  </p>
-  <p>
-    gRPConf is also happening for the first time in India on <strong>Nov. 19th!</strong> -
-    <a href="https://events.linuxfoundation.org/grpconf-india/register/" target="_blank" rel="noopener">
-      <strong>Register now</strong>
-    </a>
-    with Early Bird tickets (INR 900) or 
-    <a href="https://events.linuxfoundation.org/grpconf-india/program/cfp/" target="_blank" rel="noopener">
-      <strong>Submit a Talk now</strong>
-    </a>
+     <a href="https://events.linuxfoundation.org/grpconf-india/" target="_blank" rel="noopener">gRPConf India</a> is happening for the first time on <strong>Nov. 19th!</strong>
   </p>
 </div>
 {{ end -}}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,7 +1,9 @@
 {{ if site.Params.show_banner -}}
 <div class="o-banner">
   <p>
-     <a href="https://events.linuxfoundation.org/grpconf-india/" target="_blank" rel="noopener">gRPConf India</a> is happening for the first time on <strong>Nov. 19th!</strong>
+     gRPConf India is happening for the first time on <strong>Nov. 19th!</strong> <a href="https://events.linuxfoundation.org/grpconf-india/" target="_blank" rel="noopener">Learn more!</a>
   </p>
+     
+
 </div>
 {{ end -}}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -3,7 +3,5 @@
   <p>
      gRPConf India is happening for the first time on <strong>Nov. 19th!</strong> <a href="https://events.linuxfoundation.org/grpconf-india/" target="_blank" rel="noopener">Learn more!</a>
   </p>
-     
-
 </div>
 {{ end -}}


### PR DESCRIPTION
Removed gRPC Conf US info from banner and modified to just mention about gRPCOnf India. Removed the registration link since it is closed now.
<img width="754" height="244" alt="Screenshot 2025-10-06 at 11 41 56 AM" src="https://github.com/user-attachments/assets/3e486194-fe20-48ae-ab64-fd326fc40f4f" />


