### PR TITLE
Remove banner

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@ params:
     navbar_translucent_over_cover_disable: true
     sidebar_menu_compact: true
 
-  show_banner: true
+  show_banner: false
 
   fonts:
     - name: Open Sans


### PR DESCRIPTION
gRPConf India is in the past, we can remove the banner until there are new events scheduled.