### PR TITLE
Update gRPC Go version to 1.80.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ params:
   locale: en_US
   grpc_vers:
     core: v1.78.1
-    go: v1.79.1
+    go: v1.80.0
     java: v1.80.0
     node: "@grpc/grpc-js@1.9.0"
   font_awesome_version: 5.12.1


### PR DESCRIPTION
gRPC Go 1.80.0 is released: https://github.com/grpc/grpc-go/releases/tag/v1.80.0