### PR TITLE
Add grpc-rust documentation: language landing page, quickstart, and route guide (#1511)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,7 @@ params:
     go: v1.81.1
     java: v1.81.0
     node: "@grpc/grpc-js@1.9.0"
+    rust: v0.9.0
   font_awesome_version: 5.12.1
   gcs_engine_id: 788f3b1ec3a111a2f
   ui:

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -32,6 +32,7 @@ Learn more
 - [Go]({{< relref "/docs/languages/go/quickstart" >}})
 - [C++]({{< relref "/docs/languages/cpp/quickstart" >}})
 - [Java]({{< relref "/docs/languages/java/quickstart" >}})
+- [Rust]({{< relref "/docs/languages/rust/quickstart" >}})
 - [Python]({{< relref "/docs/languages/python/quickstart" >}})
 - [<i class="fas fa-ellipsis-h" aria-label="Supported languages"></i>]({{< relref "languages" >}})
 </div>
@@ -51,10 +52,10 @@ backend services.
 </section>
 <div class="youtube-video-center">
     <div class="video-wrapper">
-        <iframe 
-            src="https://www.youtube.com/embed/5dMK5OW6WSw" 
-            title="Ten Years of gRPC" 
-            frameborder="0" 
+        <iframe
+            src="https://www.youtube.com/embed/5dMK5OW6WSw"
+            title="Ten Years of gRPC"
+            frameborder="0"
             allowfullscreen>
         </iframe>
     </div>

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -38,7 +38,7 @@ This release includes:
 
 ## Learn more
 
-Documentation for this gRPC-Rust preview is now available on
+Documentation for this gRPC-Rust preview can be found on
 [grpc.io](https://grpc.io/docs/languages/rust/).  The following resources are
 available:
 

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -19,16 +19,19 @@ experiment with the APIs and ensure they will be acceptable for their needs.
 
 This release includes:
 
-* Protobuf support using Google's [Protobuf-Rust
+* **gRPC Client APIs**.  Includes all RPC types including unary and streaming.
+  * gRPC Server support is coming soon.
+
+* **Protobuf support** using Google's [Protobuf-Rust
   library](https://github.com/protocolbuffers/protobuf) and tools.
 
   * Messages are generated from Protobuf-Rust via `protoc`.
   * gRPC generated RPC code using our `protoc` plugin.
 
-* Low-level RPC API for creating interceptors and performing RPCs without the
-  need for the protobuf generated code.
+* **Low-level RPC API** for creating interceptors and performing RPCs without
+  the need for the protobuf generated code.
 
-* Support for the [Tokio](https://tokio.rs/) [async
+* Support for the **[Tokio](https://tokio.rs/)** [async
   runtime](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html#async-runtimes).
   * Future gRPC-Rust releases intend to work with any runtime; however, for this
     preview we are only targetting Tokio.

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -58,3 +58,6 @@ others in the industry, or maybe even sharing your own experiences or advice in
 a talk, please mark your calendar for **Thursday, September 3rd**, when we'll be
 holding this year's gRPC developer's conference at the [Computer History
 Museum](https://computerhistory.org/) in Mountain View, CA.
+
+* **Event Site:** [gRPConf](https://events.linuxfoundation.org/grpconf/)
+* **CFP is open:** [Submit your talk!](https://events.linuxfoundation.org/grpconf/program/cfp/)

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -1,6 +1,6 @@
 ---
 title: gRPC-Rust Preview Release
-date: 2026-05-18
+date: 2026-05-27
 spelling: cSpell:ignore Tokio
 author:
   name: Doug Fawley

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -1,0 +1,60 @@
+---
+title: gRPC-Rust Preview Release
+date: 2026-05-18
+spelling: cSpell:ignore Tokio
+author:
+  name: Doug Fawley
+  position: Google
+---
+
+Today, the gRPC project is excited to share its first preview release of
+gRPC-Rust.  It can be found at
+[crates.io/crates/grpc](https://crates.io/crates/grpc).  Documentation is
+available on our website, [grpc.io](https://grpc.io/docs/languages/rust).  This
+release is not recommended for production use at this time, but is being
+released at an early stage to provide Rust programmers with an opportunity to
+experiment with the APIs and ensure they will be acceptable for their needs.
+
+## What is included
+
+This release includes:
+
+* Protobuf support using Google's [Protobuf-Rust
+  library](https://github.com/protocolbuffers/protobuf) and tools.
+
+  * Messages are generated from Protobuf-Rust via `protoc`.
+  * gRPC generated RPC code using our `protoc` plugin.
+
+* Low-level RPC API for creating interceptors and performing RPCs without the
+  need for the protobuf generated code.
+
+* Support for the [Tokio](https://tokio.rs/) [async
+  runtime](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html#async-runtimes).
+  * Future gRPC-Rust releases intend to work with any runtime; however, for this
+    preview we are only targetting Tokio.
+
+## Learn more
+
+Documentation for this gRPC-Rust preview is now available on
+[grpc.io](https://grpc.io/docs/languages/rust/).  The following resources are
+available:
+
+* [Generated code reference](https://grpc.io/docs/languages/rust/generated-code)
+* [Quick start guide](https://grpc.io/docs/languages/rust/quickstart)
+* [Basics tutorial](https://grpc.io/docs/languages/rust/basics) that covers each
+  of the four RPC types.
+
+## Contact the team
+
+Please reach out to the team if you have any feedback or encounter any issues:
+
+* Bugs/Feature Requests: [Github Repo](https://github.com/grpc/grpc-rust)
+* Discussions: [Google Groups](https://groups.google.com/g/grpc-io)
+
+## Join us at gRPConf 2026!
+
+If you're interested in meeting the gRPC team, discussing related topics with
+others in the industry, or maybe even sharing your own experiences or advice in
+a talk, please mark your calendar for **Thursday, September 3rd**, when we'll be
+holding this year's gRPC developer's conference at the [Computer History
+Museum](https://computerhistory.org/) in Mountain View, CA.

--- a/content/en/blog/grpc-rust-announcement.md
+++ b/content/en/blog/grpc-rust-announcement.md
@@ -1,6 +1,6 @@
 ---
 title: gRPC-Rust Preview Release
-date: 2026-05-27
+date: 2026-05-28
 spelling: cSpell:ignore Tokio
 author:
   name: Doug Fawley

--- a/content/en/docs/languages/rust/_index.md
+++ b/content/en/docs/languages/rust/_index.md
@@ -1,0 +1,16 @@
+---
+title: Rust
+prog_lang_home: true
+api_path: https://docs.rs/grpc
+content:
+  - learn_more:
+    - "[Examples]($src_repo_url/tree/master/examples)"
+  - reference:
+    - "[API](api/)"
+    - "[Generated code](generated-code/)"
+  - other:
+    - $src_repo_link
+spelling: cSpell:ignore youtube
+---
+
+{{% docs/prog-lang-home-content %}}

--- a/content/en/docs/languages/rust/api.md
+++ b/content/en/docs/languages/rust/api.md
@@ -1,0 +1,8 @@
+---
+title: API reference
+linkTitle: API
+weight: 90
+# Note: this is a placeholder page. The URL to this page redirects elsewhere.
+manualLinkTarget: _blank
+_build: { render: link }
+---

--- a/content/en/docs/languages/rust/basics.md
+++ b/content/en/docs/languages/rust/basics.md
@@ -1,0 +1,418 @@
+---
+title: Basics tutorial
+description: A basic tutorial introduction to gRPC in Rust.
+weight: 50
+spelling: cSpell:ignore struct
+---
+
+This tutorial provides a basic Rust programmer's introduction to working with
+gRPC.
+
+By walking through this example you'll learn how to:
+
+- Define a service in a `.proto` file.
+- Generate client code using the protocol buffer compiler.
+- Use the Rust gRPC API to write a simple client for your service.
+
+It assumes that you have read the [Introduction to
+gRPC](/docs/what-is-grpc/introduction/) and are familiar with [protocol
+buffers](https://protobuf.dev/overview).  Note that the example in this tutorial
+uses the proto3 version of the protocol buffers language: you can find out more
+in the [proto3 language guide](https://protobuf.dev/programming-guides/proto3)
+and the [Rust generated code
+guide](https://protobuf.dev/reference/rust/rust-generated).  Note that
+protobuf-Rust is also still in a preview state and their APIs may be unstable.
+
+> NOTE: server-side support is not yet available in this version of grpc-Rust.
+> This guide will be updated when it is.
+
+### Why use gRPC?
+
+{{< why-grpc >}}
+
+### Setup
+
+You should have already installed the tools needed to generate client and server
+interface code -- if you haven't, see the [Prerequisites][] section of [Quick
+start][] for setup instructions.
+
+### Get the example code
+
+The example code is part of the [grpc-rust][] repo.
+
+ 1. [Download the repo as a zip file][download] and unzip it, or clone
+    the repo:
+
+    ```sh
+    git clone -b {{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
+    ```
+
+ 2. Change to the examples directory:
+
+    ```sh
+    cd grpc-rust/examples
+    ```
+
+### Defining the service
+
+Our first step (as you'll know from the [Introduction to
+gRPC](/docs/what-is-grpc/introduction/)) is to define the gRPC *service* and the
+method *request* and *response* types using [protocol
+buffers](https://protobuf.dev/overview).  For the complete `.proto` file, see
+[routeguide/route_guide.proto](https://github.com/grpc/grpc-rust/blob/master/examples/proto/routeguide/route_guide.proto).
+
+To define a service, you specify a named `service` in your `.proto` file:
+
+```proto
+service RouteGuide {
+   ...
+}
+```
+
+Then you define `rpc` methods inside your service definition, specifying their
+request and response types. gRPC lets you define four kinds of service method,
+all of which are used in the `RouteGuide` service:
+
+- A *simple RPC* where the client sends a request to the server using the stub
+  and waits for a response to come back, just like a normal function call.
+
+  ```proto
+  // Obtains the feature at a given position.
+  rpc GetFeature(Point) returns (Feature) {}
+  ```
+
+- A *server-side streaming RPC* where the client sends a request to the server
+  and gets a stream to read a sequence of messages back. The client reads from
+  the returned stream until there are no more messages. As you can see in our
+  example, you specify a server-side streaming method by placing the `stream`
+  keyword before the *response* type.
+
+  ```proto
+  // Obtains the Features available within the given Rectangle.  Results are
+  // streamed rather than returned at once (e.g. in a response message with a
+  // repeated field), as the rectangle may cover a large area and contain a
+  // huge number of features.
+  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+  ```
+
+- A *client-side streaming RPC* where the client writes a sequence of messages
+  and sends them to the server, again using a provided stream. Once the client
+  has finished writing the messages, it waits for the server to read them all
+  and return its response. You specify a client-side streaming method by placing
+  the `stream` keyword before the *request* type.
+
+  ```proto
+  // Accepts a stream of Points on a route being traversed, returning a
+  // RouteSummary when traversal is completed.
+  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+  ```
+
+- A *bidirectional streaming RPC* where both sides send a sequence of messages
+  using a read-write stream. The two streams operate independently, so clients
+  and servers can read and write in whatever order they like: for example, the
+  server could wait to receive all the client messages before writing its
+  responses, or it could alternately read a message then write a message, or
+  some other combination of reads and writes. The order of messages in each
+  stream is preserved. You specify this type of method by placing the `stream`
+  keyword before both the request and the response.
+
+  ```proto
+  // Accepts a stream of RouteNotes sent while a route is being traversed,
+  // while receiving other RouteNotes (e.g. from other users).
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+  ```
+
+Our `.proto` file also contains protocol buffer message type definitions for all
+the request and response types used in our service methods - for example, here's
+the `Point` message type:
+
+```proto
+// Points are represented as latitude-longitude pairs in the E7 representation
+// (degrees multiplied by 10**7 and rounded to the nearest integer).
+// Latitudes should be in the range +/- 90 degrees and longitude should be in
+// the range +/- 180 degrees (inclusive).
+message Point {
+  int32 latitude = 1;
+  int32 longitude = 2;
+}
+```
+
+### Generating client code
+
+Next we need to generate the gRPC client code from our `.proto` service
+definition. We do this using the protocol buffer compiler `protoc` with a
+special gRPC Rust plugin. This is similar to what we did in the [Quick start][].
+
+From the `examples/` directory, run the following command:
+
+```sh
+protoc \
+   --rust_out=src/grpc-routeguide/generated/ --rust_opt=experimental-codegen=enabled,kernel=upb \
+   --rust-grpc_out=src/grpc-routeguide/generated/ --rust-grpc_opt=client_only=true \
+   --proto_path=proto/routeguide/ \
+   proto/routeguide/route_guide.proto
+```
+
+Running this command generates the following files in the
+[routeguide](https://github.com/grpc/grpc-rust/blob/master/examples/src/grpc-routeguide/generated) directory:
+
+- `route_guide.u.pb.rs`, which contains all the protocol buffer code to
+  populate, serialize, and retrieve request and response message types.
+- `route_guide_grpc.pb.rs`, which contains a wrapper type (or *stub*) for
+  clients to call with the methods defined in the `RouteGuide` service.
+- `generated.rs`, a helper for the protobuf message generated code.
+
+### Including the generated code in your application
+
+To include this generated code in our application, add the following to your
+crate (often in the top-level mod.rs or lib.rs):
+
+```rust
+mod generated {
+    pub mod routeguide {
+        include!("generated/generated.rs"); // Contains messages
+        include!("generated/route_guide_grpc.pb.rs"); // Contains grpc stubs
+    }
+}
+```
+
+### Creating the client {#client}
+
+In this section, we'll look at creating a Rust client for our `RouteGuide`
+service. You can see our complete example client code in
+[grpc-rust/examples/src/grpc-routeguide/client.rs](https://github.com/grpc/grpc-rust/master/tree/examples/src/grpc-routeguide/client.rs).
+
+#### Creating a stub
+
+To call service methods, we first need to create a gRPC *channel* to communicate
+with the server. We create this by passing the server address and port number to
+`Channel::new()` as follows:
+
+```rust
+use grpc::client::Channel;
+
+let channel = Channel::new(
+    format!("dns:///{address}"),
+    Arc::new(LocalChannelCredentials::new()),
+    ChannelOptions::default(),
+);
+```
+
+You can substitute the `LocalChannelCredentials` with another credentials
+implementation (for example, TLS, GCE credentials, or JWT credentials) when a
+service requires them. The `RouteGuide` service doesn't require any credentials.
+"Local" credentials is a safe plaintext credential type that verifies it is
+connecting to a local address, or fails to establish the connection.  You should
+always have a strong credential type when connecting to any remote peer.
+
+Once the gRPC *channel* is set up, we need a client *stub* to perform RPCs. We
+get it using the `RouteGuideClient::new` method provided by the code generated
+from the example `.proto` file.
+
+```rust
+use crate::generated::routeguide::route_guide_client::RouteGuideClient;
+
+let client = RouteGuideClient::new(channel);
+```
+
+#### Calling service methods
+
+Now let's look at how we call our service methods. Note that in gRPC-Rust, all
+RPCs and their operations are implemented with async functions, which means that
+you will typically `.await` them to wait for them to complete.
+
+##### Simple RPC
+
+Calling the simple RPC `GetFeature` is just like calling a local async method.
+
+```rust
+let feature = client
+    .get_feature(proto!(Point{latitude: 409146138, longitude: -746188906}))
+    .await?; // Optional: use `.map_err()` to transform errors before propagating.
+```
+
+As you can see, we call the method on the stub we got earlier. In our method
+parameter we create and populate a request protocol buffer object (in our case
+`Point`).  If the call doesn't return an error, then `feature` will be the
+response information from the server.
+
+```rust
+// This is sufficient to print feature's "debug" information but we implement
+// prettier output in the example application.
+println!("{feature:?}");
+```
+
+##### Server-side streaming RPC
+
+Here's where we call the server-side streaming method `ListFeatures`, which
+returns a stream of geographical `Feature`s.
+
+```rust
+// Initialize a Rectangle:
+let rect = proto!(Rectangle{...});
+
+// Start the RPC.
+let mut response_stream = client.list_features(rect).await;
+
+// Receive the response messages.
+while let Some(feature) = response_stream.recv().await {
+    print_feature(feature);
+}
+
+// Confirm the status.
+let status = response_stream.status().await;
+assert!(status.is_ok(), "{status:?}");
+```
+
+As in the simple RPC, we pass the method the request. However, instead of
+getting a response object back, we get back an instance of
+`GrpcStreamingResponse<Feature>`.  We use the `GrpcStreamingResponse`'s `recv()`
+method to repeatedly read in the server's responses to a response protocol
+buffer object (in this case a `Feature`) until there are no more messages, i.e.
+until `None` is returned.  At that time, the client needs to check the status
+returned by the `status()` method.  If it is `.ok()`, the RPC succeeded;
+otherwise it will contain the failure information.
+
+##### Client-side streaming RPC
+
+The client-side streaming method `RecordRoute` is similar to the server-side
+method, except that we pass no parameters to the method and get a
+`ClientStreamingCall` back, which we can use to both write messages *and* read
+the final response message or the status if an error occurred.
+
+```rust
+// Create a random number of random points.
+let point_count = rand::random_range(2..=30); // Traverse at least two points
+let mut points = Vec::with_capacity(point_count);
+for _ in 0..point_count {
+    points.push(random_point());
+}
+println!("Traversing {point_count} points.");
+
+// Start the RPC.
+let mut stream = client.record_route().await;
+
+// Send the request messages.
+for point in points {
+    if stream.send(&point).await.is_err() {
+        // RPC terminated early; abort sending and the response stream
+        // will provide the RPC status.
+        break;
+    }
+}
+
+// Receive the response or status.
+let response = stream.close_and_recv().await.expect("RPC failed");
+println!(
+    "Route summary: Point count: {}, Distance: {}",
+    response.point_count(),
+    response.distance()
+);
+```
+
+The `ClientStreamingCall` has a `send()` method that we can use to send requests
+to the server. Once we've finished writing our client's requests to the stream
+using `send()`, we need to call `close_and_recv()` on the stream to let gRPC
+know that we've finished writing and are expecting to receive a response.  We
+get our response message or the RPC status from that operation.
+
+##### Bidirectional streaming RPC
+
+Finally, let's look at our bidirectional streaming RPC `RouteChat()`. As in the
+case of `RecordRoute`, we pass no parameters to the method when we call it.
+This time, however, we receive two streaming objects, `GrpcStreamingRequest` and
+`GrpcStreamingResponse`, that we can use to write and read messages,
+respectively. This allows us to send values via our method's stream while the
+server is still sending messages to *their* message stream.
+
+```rust
+// Start the RPC.
+let (mut tx, mut rx) = client.route_chat().await;
+
+// Spawn a task to send the request messages asynchronously.
+let handle = tokio::task::spawn(async move {
+    for note in notes {
+        if tx.send(note).await.is_err() {
+            // RPC terminated early; abort sending and the response stream
+            // will provide the RPC status.
+            return;
+        }
+    }
+    // Indicate to the server that we are done sending requests.  This also
+    // triggers naturally if `tx` is dropped, which will happen automatically
+    // at the end of this task.
+    tx.close();
+});
+
+// Receive the response messages in the current task.
+while let Some(response) = rx.recv().await {
+    println!(
+        "Got message {} at Point: {{{}, {}}}",
+        response.message(),
+        response.location().latitude(),
+        response.location().longitude()
+    );
+}
+
+// Confirm the status.
+let status = rx.status().await;
+assert!(status.is_ok(), "{status:?}");
+
+// Wait for the spawned task to complete as part of proper resource cleanup.
+handle.await.unwrap();
+```
+
+The syntax for reading and writing here is very similar to our client-side and
+server-side streaming methods, except we use the `GrpcStreamingRequest`'s
+`close()` method once we've finished our call.  Note that this happens
+automatically via its `Drop` implementation as well.  Although each side will
+always get the other's messages in the order they were written, both the client
+and server can read and write in any order — the streams operate completely
+independently.
+
+### Try it out!
+
+Execute the following commands from the `examples/route_guide` directory:
+
+ 1. Run the tonic routeguide server:
+
+    ```sh
+    cargo run --bin routeguide-server
+    ```
+
+ 2. From another terminal, run the client:
+
+    ```sh
+    cargo run --bin grpc-routeguide-client
+    ```
+
+You'll see output like this:
+
+```nocode
+Connecting to [::1]:10000...
+*** SIMPLE RPC ***
+Response = Name = "Berkshire Valley Management Area Trail, Jefferson, NJ, USA", Point: {409146138, -746188906}
+*** MISSING FEATURE ***
+Response = Name = "", Point: {0, 0}
+*** FEATURES IN RANGE ***
+Response = Name = "Patriots Path, Mendham, NJ 07945, USA", Point: {407838351, -746143763}
+Response = Name = "101 New Jersey 10, Whippany, NJ 07981, USA", Point: {408122808, -743999179}
+...
+*** RECORD ROUTE ***
+Traversing 29 points.
+Route summary: Point count: 29, Distance: 313071718
+*** ROUTE CHAT ***
+Got message Message One at Point: {0, 1}
+Got message Message Two at Point: {0, 2}
+Got message Message Three at Point: {0, 3}
+Got message Message One at Point: {0, 1}
+Got message Message Four at Point: {0, 1}
+Got message Message One at Point: {0, 1}
+Got message Message Four at Point: {0, 1}
+Got message Message Five at Point: {0, 1}
+```
+
+[download]: https://github.com/grpc/grpc-rust/archive/{{< param grpc_vers.rust >}}.zip
+[grpc-rust]: https://github.com/grpc/grpc-rust
+[Prerequisites]: ../quickstart/#prerequisites
+[Quick start]: ../quickstart/

--- a/content/en/docs/languages/rust/basics.md
+++ b/content/en/docs/languages/rust/basics.md
@@ -44,7 +44,7 @@ The example code is part of the [grpc-rust][] repo.
     the repo:
 
     ```sh
-    git clone -b {{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
+    git clone -b grpc-{{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
     ```
 
  2. Change to the examples directory:
@@ -141,9 +141,26 @@ message Point {
 
 Next we need to generate the gRPC client code from our `.proto` service
 definition. We do this using the protocol buffer compiler `protoc` with a
-special gRPC Rust plugin. This is similar to what we did in the [Quick start][].
+special gRPC Rust plugin and `build.rs` integration.  This is similar to what we
+did in the [Quick start][] -- please refer to this guide for more information on
+how this works.
 
-From the `examples/` directory, run the following command:
+From the `examples/` directory, do one of the following:
+
+1. If you installed `protoc` and `protoc-gen-rust-grpc` into your path:
+
+```sh
+GRPC_RUST_REGENERATE_PROTO=1 cargo build --bin grpc-routeguide-client
+```
+
+2. If you prefer to build these tools from source with a C++ compiler and CMake
+   as described above:
+
+```sh
+GRPC_RUST_REGENERATE_PROTO=1 cargo build --bin grpc-routeguide-client --features grpc-protobuf-build/build-plugin
+```
+
+3. If you'd like to run `protoc` manually from the command-line:
 
 ```sh
 protoc \
@@ -153,8 +170,9 @@ protoc \
    proto/routeguide/route_guide.proto
 ```
 
-Running this command generates the following files in the
-[routeguide](https://github.com/grpc/grpc-rust/blob/master/examples/src/grpc-routeguide/generated) directory:
+Doing any of these generates the following files in the
+[routeguide](https://github.com/grpc/grpc-rust/blob/master/examples/src/grpc-routeguide/generated)
+directory:
 
 - `route_guide.u.pb.rs`, which contains all the protocol buffer code to
   populate, serialize, and retrieve request and response message types.
@@ -412,7 +430,7 @@ Got message Message Four at Point: {0, 1}
 Got message Message Five at Point: {0, 1}
 ```
 
-[download]: https://github.com/grpc/grpc-rust/archive/{{< param grpc_vers.rust >}}.zip
+[download]: https://github.com/grpc/grpc-rust/archive/grpc-{{< param grpc_vers.rust >}}.zip
 [grpc-rust]: https://github.com/grpc/grpc-rust
 [Prerequisites]: ../quickstart/#prerequisites
 [Quick start]: ../quickstart/

--- a/content/en/docs/languages/rust/generated-code.md
+++ b/content/en/docs/languages/rust/generated-code.md
@@ -35,8 +35,10 @@ binary, which is currently required to be `4.34.0-release`.
 
 Using this approach ensures that your generated code is always up to date as
 changes are made to your proto definitions.  However, it requires anyone who
-wants to compile your crate to have `protoc` installed, and the proper C++
-requirements for building the `protoc-gen-rust-grpc` binary.
+wants to compile your crate to have the proper C++ requirements for building the
+`protoc-gen-rust-grpc` crate.  Alternatively, you can disable the feature flag
+`grpc-protobuf-build/build-plugin` (on by default).  Doing this means users will
+need to have `protoc` and `protoc-gen-rust-grpc` available in their PATH.
 
 To implement this method, add the `grpc-protobuf-build` crate to the
 `[build-dependencies]` section of your project's `Cargo.toml`.  Then, add the

--- a/content/en/docs/languages/rust/generated-code.md
+++ b/content/en/docs/languages/rust/generated-code.md
@@ -1,0 +1,275 @@
+---
+title: Generated-code reference
+linkTitle: Generated code
+weight: 95
+---
+
+This page describes the code generated when compiling protobuf definition
+(`.proto`) files with `protoc`, using the `protoc-gen-rust-grpc` [grpc
+plugin](https://github.com/grpc/grpc-rust/tree/master/protoc-gen-rust-grpc).
+For using protobuf messages, please see the [Protobuf Rust Generated Code
+Guide](https://protobuf.dev/reference/rust/rust-generated).
+
+You can find out how to define a gRPC service in a `.proto` file in [Service
+definition](/docs/what-is-grpc/core-concepts/#service-definition).
+
+## Generating the code
+
+There are two main ways to generate the stubs you will use in your application:
+
+1. Using the
+   [`grpc-protobuf-build`](https://docs.rs/grpc-protobuf-build)
+   crate in a [`build.rs`
+   script](https://doc.rust-lang.org/cargo/reference/build-scripts.html).
+2. Running the [`protoc`](https://github.com/protocolbuffers/protobuf/releases)
+   binary manually with the
+   [`protoc-gen-rust-grpc`](https://github.com/grpc/grpc-rust/tree/master/protoc-gen-rust-grpc)
+   plugin and committing the output into revision control as needed.
+
+Both methods require adding the following dependencies to your Rust project:
+`grpc`, `protobuf`, and `grpc-protobuf`.  Your `protobuf` dependency's version
+must match the version of `protobuf` used by `grpc-protobuf` and your `protoc`
+binary, which is currently required to be `4.34.0-release`.
+
+### Method 1: using `grpc-protobuf-build` with `build.rs`
+
+Using this approach ensures that your generated code is always up to date as
+changes are made to your proto definitions.  However, it requires anyone who
+wants to compile your crate to have `protoc` installed, and the proper C++
+requirements for building the `protoc-gen-rust-grpc` binary.
+
+To implement this method, add the `grpc-protobuf-build` crate to the
+`[build-dependencies]` section of your project's `Cargo.toml`.  Then, add the
+following to your `build.rs`:
+
+```rust
+// Assumes /your/crate/root/ contains proto/<example>/<example>.proto
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    grpc_protobuf_build::CodeGen::new()
+        .include("proto/<example>")
+        .inputs(["<example>.proto"])
+        .compile()?;
+    Ok(())
+}
+```
+
+Include the generated code by adding this to your application:
+
+```rust
+mod example {
+    grpc::include_proto!("proto/<example>", "<example>");
+}
+```
+
+For more details, please see the crate documentation for
+[`grpc-protobuf-build`](https://docs.rs/grpc-protobuf-build).
+
+### Method 2: running `protoc`
+
+With this approach, you only generate code on demand and commit it to version
+control, reducing the dependencies on the build environment itself.  If updates
+are made to the input `.proto` files, you must remember to re-run these steps.
+
+First, ensure the `protoc-gen-rust-grpc` binary is compiled and available in
+your system `PATH`.  Then run `protoc` as follows (replacing `<example>` with
+your specific filenames):
+
+```sh
+# Current directory: /your/crate/root/
+protoc \
+   --rust_out=src/<example>/generated/ --rust_opt=experimental-codegen=enabled,kernel=upb \
+   --rust-grpc_out=src/<example>/generated --rust-grpc_opt=client_only=true \
+   --proto_path=proto/<example>/ \
+   proto/<example>/<example>.proto
+```
+
+Include the generated code by adding this to your application:
+
+```rust
+// In src/mod.rs:
+mod example {
+    mod generated {
+        include!("generated/generated.rs");         // Contains messages
+        include!("generated/<example>_grpc.pb.rs"); // Contains grpc stubs
+    }
+}
+```
+
+The exact patterns you use can be customized as desired.  For example, you may
+wish to include these files in a sub-module and `pub(crate)` the module
+definitions.
+
+## Methods on generated server interfaces (Coming Soon)
+
+The current gRPC-Rust preview does not support server-side code generation.
+This will be added in a future preview version.
+
+## Methods on generated client interfaces
+
+For client side usage, each `service Bar` in the `.proto` file results in the
+generation of a corresponding stub and a constructor: `BarClient::new(channel:
+T)`, which accepts a `grpc::Channel` (or any type that implements
+`grpc::client::Invoke`) and returns a `BarClient` instance.
+
+NOTE: For each RPC method in the service, a corresponding method is generated in
+the stub.  These methods utilize the [async
+builder](https://doc.rust-lang.org/std/future/trait.IntoFuture.html#async-builders)
+pattern to make them natural to use but also simple to configure or to invoke in
+other ways for specialized use cases.
+
+### Common Call Builder Configuration
+
+For all four types of RPCs, the method to start the RPC returns an object that
+implements `grpc_protobuf::client::CallBuilder`.  This allows configuration of
+the call before it is started by `await`ing it to activate its `IntoFuture`
+implementation.  An example of configuring a unary call would be:
+
+```rust
+let result = client
+    .unary_call(request)
+    .with_timeout(Duration::from_millis(100))  // <-- add a deadline
+    .with_interceptor(interceptor)             // <-- add an interceptor
+    .await;                                    // dispatch the call
+```
+
+### Unary Methods
+
+Unary methods have the following signature on the generated client stub:
+
+```rust
+pub fn foo(&self, request: RequestMsgView) -> UnaryCallBuilder<..>
+```
+
+Note that `RequestMsgView` is actually a complex generic type that allows the
+use of either owned protobuf messages or *views* of protobuf messages.  The
+concept of protobuf message view types is described in some detail in the
+[Protobuf Rust Generated Code
+Guide](https://protobuf.dev/reference/rust/rust-generated/#message-proxy-types).
+
+As mentioned above, the returned `UnaryCallBuilder` can be configured via the
+methods on the `CallBuilder` it implements before dispatching the call.
+
+A unary call can be dispatched in two different ways:
+
+```rust
+// Simple:
+let result: Result<ResponseMsg, StatusError> = client.foo(request).await;
+
+// Flexible:
+let response = ResponseMsg::new();
+let status: Status = client
+    .foo(request)
+    .with_response_message(&mut response) // <-- populated in place on success
+    .await;
+```
+
+### Server-Streaming methods
+
+Server-streaming methods have the following signature on the generated client
+stub:
+
+```rust
+pub fn foo(&self, request: RequestMsgView) -> ServerStreamingCallBuilder<..>
+```
+
+As with unary calls, the request is passed as a complex `View` generic.
+However, there is only one way to dispatch the call, which is to `.await` it.
+This returns a `grpc_protobuf::client::GrpcStreamingResponse<ResponseMsg>` used
+to retrieve the messages and status from the stream.
+
+Usage example:
+
+```rust
+// Begin the call:
+let response_stream: GrpcStreamingResponse<_> = client.foo(request).await;
+
+// Process response messages:
+while let Some(response: ResponseMsg) = response_stream.recv().await {
+    process(response);
+}
+// Receive the status of the RPC:
+let status: Status = response_stream.status().await;
+```
+
+### Client-Streaming methods
+
+Client-streaming methods have the following signature on the generated client
+stub:
+
+```rust
+pub fn foo(&self) -> ClientStreamingCallBuilder<..>
+```
+
+Client-streaming calls do not begin with a request message -- instead, they are
+streamed to the object (a
+`grpc_protobuf::client::client_streaming::ClientStreamingCall`) returned by
+`.await`ing the `ClientStreamingCallBuilder`.
+
+Usage of the `ClientStreamingCall` involves sending messages by repeatedly
+calling its `send` message until it receives an error (indicating the stream
+terminated) or the client has no more messages to send.  At this time, the
+`close_and_recv` method should be called to receive the server's response, or
+the RPC status in the event of a failure.
+
+Usage example:
+
+```rust
+// Begin the call:
+let request_stream: ClientStreamingCall<_> = client.foo().await;
+
+// Send request messages:
+while let Some(message) = get_message_to_send() {
+    if request_stream.send(message).is_err() {
+        // Stream terminated while sending messages.
+        break;
+    }
+}
+
+// Receive the response message or status of the RPC:
+let result: Result<ResponseMsg, StatusError> = request_stream.close_and_recv().await;
+```
+
+### Bidirectional-Streaming methods
+
+Bidi-streaming methods have the following signature on the generated client
+stub:
+
+```rust
+pub fn foo(&self) -> BidiCallBuilder<..>
+```
+
+Bidi-streaming calls stream messages in two directions simultaneously.  To
+properly express this parallelism, two objects are returned from the
+`BidiCallBuilder` when it is `.await`ed: a sender and a receiver.  The client
+typically interacts with these objects in separate tasks.  Like client-streaming
+calls, if an error is encountered while sending a request, the client should
+stop sending and discover the result of the RPC (which could be a success) using
+the receiver.
+
+Usage example:
+
+```rust
+// Begin the call:
+let (mut tx, mut rx) = client.foo().await;
+
+// Spawn a task for sending requests:
+let handle = tokio::task::spawn(async move {
+    while let Some(message) = get_message_to_send() {
+        if tx.send(message).is_err() {
+            // Stream terminated while sending messages.
+            return;
+        }
+    }
+    // Explicitly signal the client is done sending; note that this
+    // happens implicitly when tx is dropped.
+    tx.close();
+});
+
+// In parallel with the task above, receive responses:
+while let Some(response: ResponseMsg) = rx.recv().await {
+    // Process "response"
+}
+
+// Receive the final status of the RPC:
+let status: Status = rx.status().await;
+```

--- a/content/en/docs/languages/rust/quickstart.md
+++ b/content/en/docs/languages/rust/quickstart.md
@@ -11,20 +11,30 @@ spelling: cSpell:ignore Rust
 
   For installation instructions, see Rust's [Getting Started][] guide.
 
-- **[Protocol buffer][pb] compiler**, `protoc`, [version 34.0][proto34].
+- **Protobuf code generation tools**
 
-  For installation instructions, see [Protocol Buffer Compiler
-  Installation][pbc-install].  Note that because Rust support in `protoc` is not
-  yet stable, the version installed must be exactly 34.0.
+  There are two tools used to generate the Rust protobuf code:
 
-- **gRPC-Rust plugin** for the protocol compiler:
+  1. **[Protocol buffer][pb] compiler**, `protoc`, [version 34.0][proto34].
+     This generates the defined _message_ data structures.
+  2. **gRPC-Rust plugin**, `protoc-gen-rust-grpc`
+     This generates the defined _services_ and _methods_.
+
+  There are two options for installing these tools.
 
   1. A C++17 compatible compiler and CMake 3.14 or higher are required to
      compile the protobuf code generation tool.
-  2. Follow the detailed instructions on the [`protoc-gen-rust-grpc`][pgrg] page
-     to compile and install the plugin.
-  3. Be sure to update your `PATH` so that the `protoc` compiler can find the
-     plugin.
+  2. Alternatively, compiled versions of the tools can be downloaded from the
+     [protobuf releases] (for `protoc`) and [grpc releases] (for
+     `protoc-gen-rust-grpc`) GitHub pages.
+     * For this option, be sure to update your `PATH` to include both of the
+       binaries.
+     * For `protoc` installation instructions, see [Protocol Buffer Compiler
+       Installation][pbc-install].  Note that because Rust support in `protoc`
+       is not yet stable, the version installed must be exactly 34.0.
+
+[protobuf releases]: https://github.com/protocolbuffers/protobuf/releases
+[grpc releases]: https://github.com/grpc/grpc-rust/releases
 
 ### Get the example code
 
@@ -34,7 +44,7 @@ The example code is part of the [grpc-rust][] repo.
     the repo:
 
     ```sh
-    git clone -b {{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
+    git clone -b grpc-{{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
     ```
 
  2. Change to the `examples` directory:
@@ -121,12 +131,19 @@ Remember to save the file!
 Before you can use the new service method, you need to recompile the updated
 `.proto` file.
 
-While still in the `examples` directory, run the following command:
+From the `examples/` directory, run the following:
+
+1. If you installed `protoc` and `protoc-gen-rust-grpc` into your path:
 
 ```sh
-protoc --rust_out=src/grpc-helloworld/generated/ --rust_opt=experimental-codegen=enabled,kernel=upb \
-    --rust-grpc_out=src/grpc-helloworld/generated/ --rust-grpc_opt=client_only=true \
-    --proto_path=proto/helloworld/ proto/helloworld/helloworld.proto
+GRPC_RUST_REGENERATE_PROTO=1 cargo build --bin grpc-routeguide-client
+```
+
+2. If you prefer to build these tools from source with a C++ compiler and CMake
+   as described above:
+
+```sh
+GRPC_RUST_REGENERATE_PROTO=1 cargo build --bin grpc-routeguide-client --features grpc-protobuf-build/build-plugin
 ```
 
 This will regenerate the `generated.rs`, `helloworld.u.pb.rs`, and
@@ -136,6 +153,35 @@ contain:
 - Code for populating, serializing, and retrieving `HelloRequest` and
   `HelloReply` message types.
 - Generated client code.
+
+**How does this work?**
+
+We are leveraging the `grpc-protobuf-build` crate in `examples/build.rs` to
+perform the code generation step.  However, this is only executed when you are
+running one of our grpc-based examples _and_ when the environment variable
+`GRPC_RUST_REGENERATE_PROTO` is set.  That is, in `examples/build.rs` you will
+see something like:
+
+```rust
+  if env::var_os("GRPC_RUST_REGENERATE_PROTO").is_some() {
+      grpc_protobuf_build::CodeGen::new()
+          .output_dir(manifest_dir.join("src/grpc-helloworld/generated"))
+          .input("helloworld.proto")
+          .include(manifest_dir.join("proto/helloworld"))
+          .client_only()
+          .compile()
+          .unwrap();
+  }
+```
+
+You can run `protoc` manually, instead, to perform code generation if you don't
+wish to use build.rs integration.  To do that, you would use:
+
+```sh
+protoc --rust_out=src/grpc-helloworld/generated/ --rust_opt=experimental-codegen=enabled,kernel=upb \
+    --rust-grpc_out=src/grpc-helloworld/generated/ --rust-grpc_opt=client_only=true \
+    --proto_path=proto/helloworld/ proto/helloworld/helloworld.proto
+```
 
 ### Update and run the application
 
@@ -208,5 +254,5 @@ from the `examples/` directory:
 [proto34]: https://github.com/protocolbuffers/protobuf/releases/tag/v34.0
 [pbc-install]: /docs/protoc-installation/
 [grpc-rust]: https://github.com/grpc/grpc-rust
-[download]: https://github.com/grpc/grpc-rust/archive/{{< param grpc_vers.rust >}}.zip
+[download]: https://github.com/grpc/grpc-rust/archive/grpc-{{< param grpc_vers.rust >}}.zip
 [pgrg]: https://github.com/grpc/grpc-rust/tree/master/protoc-gen-rust-grpc

--- a/content/en/docs/languages/rust/quickstart.md
+++ b/content/en/docs/languages/rust/quickstart.md
@@ -1,0 +1,212 @@
+---
+title: Quick start
+description: This guide gets you started with gRPC in Rust with a simple working example.
+weight: 10
+spelling: cSpell:ignore Rust
+---
+
+### Prerequisites
+
+- **[Rust][]**, any version supported by the current [gRPC-Rust MSRV][].
+
+  For installation instructions, see Rust's [Getting Started][] guide.
+
+- **[Protocol buffer][pb] compiler**, `protoc`, [version 34.0][proto34].
+
+  For installation instructions, see [Protocol Buffer Compiler
+  Installation][pbc-install].  Note that because Rust support in `protoc` is not
+  yet stable, the version installed must be exactly 34.0.
+
+- **gRPC-Rust plugin** for the protocol compiler:
+
+  1. A C++17 compatible compiler and CMake 3.14 or higher are required to
+     compile the protobuf code generation tool.
+  2. Follow the detailed instructions on the [`protoc-gen-rust-grpc`][pgrg] page
+     to compile and install the plugin.
+  3. Be sure to update your `PATH` so that the `protoc` compiler can find the
+     plugin.
+
+### Get the example code
+
+The example code is part of the [grpc-rust][] repo.
+
+ 1. [Download the repo as a zip file][download] and unzip it, or clone
+    the repo:
+
+    ```sh
+    git clone -b {{< param grpc_vers.rust >}} --depth 1 https://github.com/grpc/grpc-rust
+    ```
+
+ 2. Change to the `examples` directory:
+
+    ```sh
+    cd grpc-rust/examples
+    ```
+
+### Run the example
+
+From the `examples` directory:
+
+ 1. Compile and execute the server code:
+
+    ```sh
+    cargo run --bin helloworld-server
+    ```
+
+ 2. From a different terminal, compile and execute the client code to see the
+    client output:
+
+    ```sh
+    cargo run --bin grpc-helloworld-client
+    Greeting: Hello world
+    ```
+
+Congratulations! You've just run a client-server application with gRPC.
+
+### Update the gRPC service
+
+In this section you'll update the application with an extra server method. The
+gRPC service is defined using [protocol buffers][pb]. To learn more about how to
+define a service in a `.proto` file see [Basics tutorial][].
+For now, all you need to know is that both the
+server and the client stub have a `SayHello()` RPC method that takes a
+`HelloRequest` parameter from the client and returns a `HelloReply` from the
+server, and that the method is defined like this:
+
+```protobuf
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}
+```
+
+Open `proto/helloworld/helloworld.proto` and add a new `SayHelloAgain()` method,
+with the same request and response types:
+
+```protobuf
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  // Sends another greeting
+  rpc SayHelloAgain (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}
+```
+
+Remember to save the file!
+
+### Regenerate gRPC code
+
+Before you can use the new service method, you need to recompile the updated
+`.proto` file.
+
+While still in the `examples` directory, run the following command:
+
+```sh
+protoc --rust_out=src/grpc-helloworld/generated/ --rust_opt=experimental-codegen=enabled,kernel=upb \
+    --rust-grpc_out=src/grpc-helloworld/generated/ --rust-grpc_opt=client_only=true \
+    --proto_path=proto/helloworld/ proto/helloworld/helloworld.proto
+```
+
+This will regenerate the `generated.rs`, `helloworld.u.pb.rs`, and
+`helloworld_grpc.pb.rs` files in `src/grpc-helloworld/generated/`, which
+contain:
+
+- Code for populating, serializing, and retrieving `HelloRequest` and
+  `HelloReply` message types.
+- Generated client code.
+
+### Update and run the application
+
+You have regenerated the server and client code, but you still need to implement
+and call the new method in the human-written parts of the example application.
+
+#### Update the server
+
+Open `src/helloworld/server.rs` (the legacy Tonic server) and add the following
+function to the `impl Greeter for MyGreeter` block:
+
+```rust
+    async fn say_hello_again(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello again {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+```
+
+#### Update the client
+
+Open `src/grpc-helloworld/client.rs` to add the following code to the end of the
+`main()` function body:
+
+```rust
+let response = client.say_hello_again(request).await.expect("RPC error");
+println!("Greeting: {:}", response.message());
+```
+
+Remember to save your changes.
+
+#### Run!
+
+Run the client and server like you did before. Execute the following commands
+from the `examples/` directory:
+
+ 1. Run the server:
+
+    ```sh
+    cargo run --bin helloworld-server
+    ```
+
+ 2. From another terminal, run the client. This time, add a name as a
+    command-line argument:
+
+    ```sh
+    cargo run --bin grpc-helloworld-client Alice
+    Greeting: Hello Alice!
+    Greeting: Hello again Alice!
+    ```
+
+### What's next
+
+- Learn how gRPC works in [Introduction to gRPC](/docs/what-is-grpc/introduction/)
+  and [Core concepts](/docs/what-is-grpc/core-concepts/).
+- Work through the [Basics tutorial][].
+- Explore the [API reference](../api).
+
+[Rust]: https://rust-lang.org/
+[Basics tutorial]: ../basics/
+[gRPC-Rust MSRV]: https://github.com/grpc/grpc-rust#rust-version
+[Getting Started]: https://rust-lang.org/learn/get-started/
+[pb]: https://protobuf.dev/
+[proto34]: https://github.com/protocolbuffers/protobuf/releases/tag/v34.0
+[pbc-install]: /docs/protoc-installation/
+[grpc-rust]: https://github.com/grpc/grpc-rust
+[download]: https://github.com/grpc/grpc-rust/archive/{{< param grpc_vers.rust >}}.zip
+[pgrg]: https://github.com/grpc/grpc-rust/tree/master/protoc-gen-rust-grpc

--- a/content/en/docs/languages/rust/quickstart.md
+++ b/content/en/docs/languages/rust/quickstart.md
@@ -31,7 +31,11 @@ spelling: cSpell:ignore Rust
        binaries.
      * For `protoc` installation instructions, see [Protocol Buffer Compiler
        Installation][pbc-install].  Note that because Rust support in `protoc`
-       is not yet stable, the version installed must be exactly 34.0.
+       is not yet stable, **the version installed must be exactly 34.0.**
+
+  **NOTE:** For now, to run the examples, which share some setup code with
+  `tonic`, you _must_ ensure `protoc` is in your `PATH` or set the `PROTOC`
+  environment variable to your `protoc` executable's path.
 
 [protobuf releases]: https://github.com/protocolbuffers/protobuf/releases
 [grpc releases]: https://github.com/grpc/grpc-rust/releases


### PR DESCRIPTION
This is identical to #1511, rolled back in #1516 since we don't want it live yet.