### PR TITLE
Fix outdated python support doc

### DIFF
--- a/data/officially_supported_lang_os.yaml
+++ b/data/officially_supported_lang_os.yaml
@@ -27,7 +27,7 @@
   compilers: [PHP 7.0+]
 - language: Python
   os: [Windows, Linux, Mac]
-  compilers: [Python 3.8+]
+  compilers: [Python 3.10+]
 - language: Ruby
   os: [Windows, Linux, Mac]
   compilers: [Ruby 3.1+]


### PR DESCRIPTION
https://grpc.io/docs/

We don't support 3.8 for a long time now.