### PR TITLE
Remove duplicated words in blog post and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ nvm install --lts
 
  1. Clone this repo.
  2. From a terminal window, change to the cloned repo directory.
- 3. Get NPM packages and git submodules, including the the [Docsy][] theme:
+ 3. Get NPM packages and git submodules, including the [Docsy][] theme:
     ```console
     $ npm install 
     ```

--- a/content/en/blog/optimizing-grpc-part-1.md
+++ b/content/en/blog/optimizing-grpc-part-1.md
@@ -36,7 +36,7 @@ split into three main classes, and a protobuf file describing the API:
   millisecond delay to make the example act more like a persistent database.
 * [KvRunner](https://github.com/carl-mastrangelo/kvstore/blob/01-start/src/main/java/io/grpc/examples/KvRunner.java)
   orchestrates the interaction between the client and the server.  It is the main entry point,
-  starting both the client and server in process, and waiting for the the client to execute its
+  starting both the client and server in process, and waiting for the client to execute its
   work.  The runner does work for 60 seconds and then records how many RPCs were completed.
 * [kvstore.proto](https://github.com/carl-mastrangelo/kvstore/blob/01-start/src/main/proto/kvstore.proto)
   is the protocol buffer definition of our service.  It describes exactly what clients can expect


### PR DESCRIPTION
## Summary

Removes 2 duplicated words found via regex scan (`\b(\w+)\s+\1\b`).

## Fixes

| # | File | Change |
|---|------|--------|
| 1 | `content/en/blog/optimizing-grpc-part-1.md` | "waiting for the the client" → "waiting for the client" |
| 2 | `README.md` | "including the the [Docsy][] theme" → "including the [Docsy][] theme" |

Doc-only changes, no functional impact. Both were manually verified as genuine duplicates.

> This PR was generated with AI assistance (regex scan + verification).